### PR TITLE
feat(recurring): add paid status to recurring expenses

### DIFF
--- a/.github/workflows/monthly-cron.yml
+++ b/.github/workflows/monthly-cron.yml
@@ -1,0 +1,18 @@
+name: Reset Recurring Job
+
+on:
+  schedule:
+    - cron: '10 8 1 * *' # 1st of every month at 12:10 AM PST / 1:10 AM PDT
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  trigger-emails:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger reset recurring 'paid' status
+        env:
+          CRON_SECRET: ${{ secrets['CRON_SECRET'] }}
+        run: |
+          curl -X POST https://sheppakai-budget-dev.fly.dev/api/cron/reset-recurring-paid \
+            -H "Authorization: Bearer $CRON_SECRET" \
+            -H "Content-Type: application/json"

--- a/src/lib/components/ui/data-table/data-table.svelte
+++ b/src/lib/components/ui/data-table/data-table.svelte
@@ -30,9 +30,16 @@
 		data: TData[];
 		defaultPageSize?: number;
 		showCategoryFilter?: boolean;
+		rowClassName?: (row: TData) => string;
 	};
 
-	let { data, columns, defaultPageSize = 10, showCategoryFilter = false }: DataTableProps<TData, TValue> = $props();
+	let {
+		data,
+		columns,
+		defaultPageSize = 10,
+		showCategoryFilter = false,
+		rowClassName
+	}: DataTableProps<TData, TValue> = $props();
 
 	// svelte-ignore state_referenced_locally
 	let pagination = $state<PaginationState>({ pageIndex: 0, pageSize: defaultPageSize });
@@ -44,8 +51,9 @@
 		get data() {
 			return data;
 		},
-		// svelte-ignore state_referenced_locally
-		columns,
+		get columns() {
+			return columns;
+		},
 		getCoreRowModel: getCoreRowModel(),
 		getPaginationRowModel: getPaginationRowModel(),
 		getSortedRowModel: getSortedRowModel(),
@@ -172,7 +180,7 @@
 			</Table.Header>
 			<Table.Body>
 				{#each table.getRowModel().rows as row (row.id)}
-					<Table.Row data-state={row.getIsSelected() && 'selected'}>
+					<Table.Row data-state={row.getIsSelected() && 'selected'} class={rowClassName?.(row.original)}>
 						{#each row.getVisibleCells() as cell (cell.id)}
 							<Table.Cell>
 								<FlexRender content={cell.column.columnDef.cell} context={cell.getContext()} />

--- a/src/lib/server/db/migrations/0005_tense_prodigy.sql
+++ b/src/lib/server/db/migrations/0005_tense_prodigy.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `recurring` ADD `paid` integer DEFAULT false NOT NULL;

--- a/src/lib/server/db/migrations/meta/0005_snapshot.json
+++ b/src/lib/server/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1275 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "00532a0d-d16c-45d1-81ec-13aecd3d9116",
+	"prevId": "32af014b-f591-461a-a72b-56f25103162b",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_user_id_users_id_fk": {
+					"name": "account_user_id_users_id_fk",
+					"tableFrom": "account",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"budget": {
+			"name": "budget",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"month": {
+					"name": "month",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"year": {
+					"name": "year",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"preset_type": {
+					"name": "preset_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"category_id": {
+					"name": "category_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"budget_category_id_category_id_fk": {
+					"name": "budget_category_id_category_id_fk",
+					"tableFrom": "budget",
+					"tableTo": "category",
+					"columnsFrom": ["category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"budget_user_id_users_id_fk": {
+					"name": "budget_user_id_users_id_fk",
+					"tableFrom": "budget",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"budget_created_by_users_id_fk": {
+					"name": "budget_created_by_users_id_fk",
+					"tableFrom": "budget",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"budget_updated_by_users_id_fk": {
+					"name": "budget_updated_by_users_id_fk",
+					"tableFrom": "budget",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"category": {
+			"name": "category",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"category_created_by_users_id_fk": {
+					"name": "category_created_by_users_id_fk",
+					"tableFrom": "category",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"category_updated_by_users_id_fk": {
+					"name": "category_updated_by_users_id_fk",
+					"tableFrom": "category",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"contributions": {
+			"name": "contributions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"goal_id": {
+					"name": "goal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"contributions_goal_id_savings_goals_id_fk": {
+					"name": "contributions_goal_id_savings_goals_id_fk",
+					"tableFrom": "contributions",
+					"tableTo": "savings_goals",
+					"columnsFrom": ["goal_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"contributions_user_id_users_id_fk": {
+					"name": "contributions_user_id_users_id_fk",
+					"tableFrom": "contributions",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"contributions_created_by_users_id_fk": {
+					"name": "contributions_created_by_users_id_fk",
+					"tableFrom": "contributions",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"contributions_updated_by_users_id_fk": {
+					"name": "contributions_updated_by_users_id_fk",
+					"tableFrom": "contributions",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"income": {
+			"name": "income",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"income_user_id_users_id_fk": {
+					"name": "income_user_id_users_id_fk",
+					"tableFrom": "income",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"income_created_by_users_id_fk": {
+					"name": "income_created_by_users_id_fk",
+					"tableFrom": "income",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"income_updated_by_users_id_fk": {
+					"name": "income_updated_by_users_id_fk",
+					"tableFrom": "income",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"recurring": {
+			"name": "recurring",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"merchant": {
+					"name": "merchant",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cadence": {
+					"name": "cadence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"paid": {
+					"name": "paid",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"recurring_user_id_users_id_fk": {
+					"name": "recurring_user_id_users_id_fk",
+					"tableFrom": "recurring",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"recurring_created_by_users_id_fk": {
+					"name": "recurring_created_by_users_id_fk",
+					"tableFrom": "recurring",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"recurring_updated_by_users_id_fk": {
+					"name": "recurring_updated_by_users_id_fk",
+					"tableFrom": "recurring",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"savings": {
+			"name": "savings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"savings_user_id_users_id_fk": {
+					"name": "savings_user_id_users_id_fk",
+					"tableFrom": "savings",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"savings_created_by_users_id_fk": {
+					"name": "savings_created_by_users_id_fk",
+					"tableFrom": "savings",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"savings_updated_by_users_id_fk": {
+					"name": "savings_updated_by_users_id_fk",
+					"tableFrom": "savings",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"savings_goals": {
+			"name": "savings_goals",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_amount": {
+					"name": "target_amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_date": {
+					"name": "target_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"savings_goals_user_id_users_id_fk": {
+					"name": "savings_goals_user_id_users_id_fk",
+					"tableFrom": "savings_goals",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"savings_goals_created_by_users_id_fk": {
+					"name": "savings_goals_created_by_users_id_fk",
+					"tableFrom": "savings_goals",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"savings_goals_updated_by_users_id_fk": {
+					"name": "savings_goals_updated_by_users_id_fk",
+					"tableFrom": "savings_goals",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_users_id_fk": {
+					"name": "session_user_id_users_id_fk",
+					"tableFrom": "session",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"transactions": {
+			"name": "transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"payee": {
+					"name": "payee",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"gst_amount": {
+					"name": "gst_amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"category_id": {
+					"name": "category_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"transactions_category_id_category_id_fk": {
+					"name": "transactions_category_id_category_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "category",
+					"columnsFrom": ["category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_user_id_users_id_fk": {
+					"name": "transactions_user_id_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_created_by_users_id_fk": {
+					"name": "transactions_created_by_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_updated_by_users_id_fk": {
+					"name": "transactions_updated_by_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/src/lib/server/db/migrations/meta/_journal.json
+++ b/src/lib/server/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
 			"when": 1769447535081,
 			"tag": "0004_rich_talisman",
 			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "6",
+			"when": 1771657907131,
+			"tag": "0005_tense_prodigy",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/lib/server/db/schema/recurring.ts
+++ b/src/lib/server/db/schema/recurring.ts
@@ -1,5 +1,5 @@
 import { relations, sql } from 'drizzle-orm';
-import { real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
 import { generateId } from '../utils';
 
@@ -11,6 +11,7 @@ const recurring = sqliteTable('recurring', {
 	description: text('description').notNull(),
 	cadence: text('cadence').notNull(),
 	amount: real('amount').notNull(),
+	paid: integer('paid', { mode: 'boolean' }).notNull().default(false),
 	userId: text('user_id')
 		.notNull()
 		.references(() => user.id),

--- a/src/lib/server/jobs/recurring.ts
+++ b/src/lib/server/jobs/recurring.ts
@@ -1,0 +1,6 @@
+import { getDb } from '$lib/server/db';
+import { recurring } from '$lib/server/db/schema';
+
+export async function runResetRecurringPaid() {
+	await getDb().update(recurring).set({ paid: false });
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -83,6 +83,7 @@ export type Recurring = {
 	description: string;
 	cadence: 'Monthly' | 'Yearly';
 	amount: number;
+	paid: boolean;
 	user: User;
 };
 

--- a/src/routes/(app)/setup/recurring/+page.server.ts
+++ b/src/routes/(app)/setup/recurring/+page.server.ts
@@ -1,10 +1,15 @@
+import { fail } from '@sveltejs/kit';
+import { and, eq } from 'drizzle-orm';
 import { superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 
 import { recurringSchema } from '$lib/formSchemas/finances';
+import { requireAuth } from '$lib/server/actions/auth-guard';
 import { createCrudActions } from '$lib/server/actions/crud-helpers';
+import { getDb } from '$lib/server/db';
 import { recurringQueries } from '$lib/server/db/queries';
 import { recurring } from '$lib/server/db/schema';
+import { withAuditFieldsForUpdate } from '$lib/server/db/utils';
 
 import type { PageServerLoad } from './$types';
 
@@ -13,28 +18,48 @@ export const load: PageServerLoad = async ({ locals }) => {
 		return [];
 	}
 
-	const recurrings = await recurringQueries.findAll();
+	const recurrings = await recurringQueries.findAll({
+		where: eq(recurring.userId, locals.user.id)
+	});
 
 	const form = await superValidate(zod4(recurringSchema));
 
 	return { recurrings, form };
 };
 
-export const actions = createCrudActions({
-	schema: recurringSchema,
-	table: recurring,
-	entityName: 'Recurring expense',
-	transformCreate: (data, userId) => ({
-		amount: Number(data.amount),
-		description: data.description,
-		merchant: data.merchant,
-		cadence: data.cadence,
-		userId
+export const actions = {
+	...createCrudActions({
+		schema: recurringSchema,
+		table: recurring,
+		entityName: 'Recurring expense',
+		transformCreate: (data, userId) => ({
+			amount: Number(data.amount),
+			description: data.description,
+			merchant: data.merchant,
+			cadence: data.cadence,
+			userId
+		}),
+		transformUpdate: (data) => ({
+			amount: data.amount,
+			description: data.description,
+			merchant: data.merchant,
+			cadence: data.cadence
+		})
 	}),
-	transformUpdate: (data) => ({
-		amount: data.amount,
-		description: data.description,
-		merchant: data.merchant,
-		cadence: data.cadence
+	togglePaid: requireAuth(async ({ request }, user) => {
+		const formData = await request.formData();
+		const recurringId = formData.get('id')?.toString();
+		const currentPaid = formData.get('paid')?.toString() === 'true';
+
+		if (!recurringId) {
+			return fail(400, { error: 'Recurring ID is required' });
+		}
+
+		await getDb()
+			.update(recurring)
+			.set(withAuditFieldsForUpdate({ paid: !currentPaid }, user))
+			.where(and(eq(recurring.id, recurringId), eq(recurring.userId, user.id.toString())));
+
+		return { success: true };
 	})
-});
+};

--- a/src/routes/(app)/setup/recurring/+page.svelte
+++ b/src/routes/(app)/setup/recurring/+page.svelte
@@ -20,10 +20,26 @@
 
 	let openModal = $state<boolean>(false);
 	let loading = $state(false);
+	const unpaidAsOf = new Intl.DateTimeFormat('en-US', {
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric'
+	}).format(new Date());
+
+	const getRecurringRowClass = (recurring: Recurring) => {
+		return recurring.paid ? 'bg-green-50/80 dark:bg-green-950/20' : '';
+	};
 
 	// Calculate total recurring expenses
 	let totalRecurring = $derived(
 		((data.recurrings as Recurring[]) || []).reduce((sum, item) => sum + item.amount, 0)
+	);
+
+	// Calculate total unpaid recurring expenses
+	let totalUnpaidRecurring = $derived(
+		((data.recurrings as Recurring[]) || [])
+			.filter((item) => !item.paid)
+			.reduce((sum, item) => sum + item.amount, 0)
 	);
 </script>
 
@@ -54,7 +70,11 @@
 					{#if loading}
 						<TableSkeleton rows={5} columns={4} />
 					{:else}
-						<DataTable {columns} data={data.recurrings as Recurring[]} />
+						<DataTable
+							{columns}
+							data={data.recurrings as Recurring[]}
+							rowClassName={getRecurringRowClass}
+						/>
 					{/if}
 				</div>
 			</div>
@@ -69,6 +89,22 @@
 					<div class="flex items-center justify-between">
 						<span class="text-base font-medium">Total Monthly Recurring: </span>
 						<span class="text-2xl font-bold">{formatCurrency(totalRecurring)}</span>
+					</div>
+				</div>
+			</div>
+
+			<div
+				class="mt-6 overflow-hidden rounded-lg border border-green-200/70 bg-green-50/40 shadow dark:border-green-900/60 dark:bg-green-950/20"
+			>
+				<div class="p-6">
+					<h2 class="text-center text-2xl font-bold tracking-tight">Unpaid</h2>
+					<p class="mt-1 text-center text-sm text-muted-foreground">Unpaid as of {unpaidAsOf}</p>
+					<div class="my-4 border-t"></div>
+					<div class="flex items-center justify-between">
+						<span class="text-base font-medium">Total Left to Pay: </span>
+						<span class="text-2xl font-bold text-green-700 dark:text-green-400"
+							>{formatCurrency(totalUnpaidRecurring)}</span
+						>
 					</div>
 				</div>
 			</div>

--- a/src/routes/(app)/setup/recurring/data-table-actions.svelte
+++ b/src/routes/(app)/setup/recurring/data-table-actions.svelte
@@ -4,6 +4,7 @@
 	import type { SuperValidated } from 'sveltekit-superforms';
 	import type { z } from 'zod';
 
+	import { invalidateAll } from '$app/navigation';
 	import ConfirmModal from '$lib/components/ConfirmModal.svelte';
 	import RecurringModal from '$lib/components/RecurringModal.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -20,6 +21,23 @@
 
 	let openEditModal = $state<boolean>(false);
 	let openDeleteModal = $state<boolean>(false);
+	let togglingPaid = $state<boolean>(false);
+
+	async function handleTogglePaid() {
+		togglingPaid = true;
+
+		const formData = new FormData();
+		formData.set('id', id);
+		formData.set('paid', `${Boolean(recurringData?.paid)}`);
+
+		await fetch('?/togglePaid', {
+			method: 'POST',
+			body: formData
+		});
+
+		await invalidateAll();
+		togglingPaid = false;
+	}
 </script>
 
 <DropdownMenu.Root>
@@ -34,7 +52,9 @@
 	<DropdownMenu.Content>
 		<DropdownMenu.Item onclick={() => (openEditModal = true)}>Edit</DropdownMenu.Item>
 		<DropdownMenu.Item onclick={() => (openDeleteModal = true)}>Delete</DropdownMenu.Item>
-		<DropdownMenu.Item>Paid</DropdownMenu.Item>
+		<DropdownMenu.Item onclick={handleTogglePaid} disabled={togglingPaid}>
+			{recurringData?.paid ? 'Mark Unpaid' : 'Mark Paid'}
+		</DropdownMenu.Item>
 	</DropdownMenu.Content>
 </DropdownMenu.Root>
 

--- a/src/routes/api/cron/reset-recurring-paid/+server.ts
+++ b/src/routes/api/cron/reset-recurring-paid/+server.ts
@@ -1,0 +1,25 @@
+import { type RequestHandler } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
+
+import { runResetRecurringPaid } from '$lib/server/jobs/recurring';
+import { logger } from '$lib/server/logger';
+
+export const POST: RequestHandler = async ({ request }) => {
+	const authHeader = request.headers.get('authorization');
+	const expectedToken = process.env.CRON_SECRET;
+
+	if (!authHeader || authHeader !== `Bearer ${expectedToken}`) {
+		logger.warn('⚠️ Unauthorized cron job attempt');
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	try {
+		logger.info('⏰ Starting cron job for resetting recurring "paid" status!');
+		await runResetRecurringPaid();
+		logger.info('✅ Reset recurring "paid" status job completed successfully!');
+		return json({ success: true, timestamp: new Date().toISOString() });
+	} catch (error) {
+		logger.error('❌ Reset recurring "paid" status job failed:', { error });
+		return json({ error: 'Job failed' }, { status: 500 });
+	}
+};


### PR DESCRIPTION
feat(recurring): add paid status to recurring expenses and implement …

- Updated the recurring schema to include a 'paid' boolean field.
- Created a new job to reset the 'paid' status of recurring expenses.
- Modified the recurring queries to filter by user ID.
- Enhanced the recurring page to display unpaid expenses and their total.
- Added functionality to toggle the 'paid' status from the UI.
- Implemented a cron endpoint for resetting the 'paid' status securely.