### PR TITLE
Add 12-hour time formatting and YearSwitcher component

### DIFF
--- a/src/lib/components/YearSwitcher.svelte
+++ b/src/lib/components/YearSwitcher.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import ChevronLeftIcon from '@lucide/svelte/icons/chevron-left';
+	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+
+	import { Button } from '$lib/components/ui/button';
+
+	interface Props {
+		currentYear: number;
+		onYearChange: (year: number) => void;
+	}
+
+	let { currentYear, onYearChange }: Props = $props();
+</script>
+
+<div class="flex items-center gap-2">
+	<Button
+		variant="outline"
+		size="icon"
+		class="h-11 w-11 md:h-9 md:w-9"
+		onclick={() => onYearChange(currentYear - 1)}
+	>
+		<ChevronLeftIcon class="h-4 w-4" />
+	</Button>
+	<div class="min-w-20 text-center">
+		<span class="text-base font-semibold md:text-lg">{currentYear}</span>
+	</div>
+	<Button
+		variant="outline"
+		size="icon"
+		class="h-11 w-11 md:h-9 md:w-9"
+		onclick={() => onYearChange(currentYear + 1)}
+	>
+		<ChevronRightIcon class="h-4 w-4" />
+	</Button>
+</div>

--- a/src/lib/components/YearSwitcher.svelte
+++ b/src/lib/components/YearSwitcher.svelte
@@ -16,6 +16,7 @@
 	<Button
 		variant="outline"
 		size="icon"
+		aria-label="Previous Year"
 		class="h-11 w-11 md:h-9 md:w-9"
 		onclick={() => onYearChange(currentYear - 1)}
 	>
@@ -27,6 +28,7 @@
 	<Button
 		variant="outline"
 		size="icon"
+		aria-label="Next Year"
 		class="h-11 w-11 md:h-9 md:w-9"
 		onclick={() => onYearChange(currentYear + 1)}
 	>

--- a/src/lib/server/db/queries/windowCleaningJobs.ts
+++ b/src/lib/server/db/queries/windowCleaningJobs.ts
@@ -47,5 +47,18 @@ export const windowCleaningJobQueries = {
 				sql`date(${windowCleaningJob.jobDate}) <= ${endDate}`
 			)
 		});
+	},
+
+	// Find jobs for a user within a year
+	findByYear: async (userId: string, year: number): Promise<WindowCleaningJob[]> => {
+		const startDate = `${year}-01-01`;
+		const endDate = `${year}-12-31`;
+		return baseBuilder.findAll({
+			where: and(
+				eq(windowCleaningJob.userId, userId),
+				sql`date(${windowCleaningJob.jobDate}) >= ${startDate}`,
+				sql`date(${windowCleaningJob.jobDate}) <= ${endDate}`
+			)
+		});
 	}
 };

--- a/src/lib/server/db/queries/windowCleaningJobs.ts
+++ b/src/lib/server/db/queries/windowCleaningJobs.ts
@@ -43,8 +43,8 @@ export const windowCleaningJobQueries = {
 		return baseBuilder.findAll({
 			where: and(
 				eq(windowCleaningJob.userId, userId),
-				sql`date(${windowCleaningJob.jobDate}) >= ${startDate}`,
-				sql`date(${windowCleaningJob.jobDate}) <= ${endDate}`
+				sql`date(${windowCleaningJob.jobDate}) >= date(${startDate})`,
+				sql`date(${windowCleaningJob.jobDate}) <= date(${endDate})`
 			)
 		});
 	},
@@ -56,8 +56,8 @@ export const windowCleaningJobQueries = {
 		return baseBuilder.findAll({
 			where: and(
 				eq(windowCleaningJob.userId, userId),
-				sql`date(${windowCleaningJob.jobDate}) >= ${startDate}`,
-				sql`date(${windowCleaningJob.jobDate}) <= ${endDate}`
+				sql`date(${windowCleaningJob.jobDate}) >= date(${startDate})`,
+				sql`date(${windowCleaningJob.jobDate}) <= date(${endDate})`
 			)
 		});
 	}

--- a/src/lib/server/db/queries/windowCleaningJobs.ts
+++ b/src/lib/server/db/queries/windowCleaningJobs.ts
@@ -51,8 +51,12 @@ export const windowCleaningJobQueries = {
 
 	// Find jobs for a user within a year
 	findByYear: async (userId: string, year: number): Promise<WindowCleaningJob[]> => {
-		const startDate = `${year}-01-01`;
-		const endDate = `${year}-12-31`;
+		const safeYear = Math.trunc(year);
+		if (!Number.isFinite(safeYear) || safeYear < 1 || safeYear > 9999) {
+			throw new Error(`Invalid year: ${year}`);
+		}
+		const startDate = `${safeYear}-01-01`;
+		const endDate = `${safeYear}-12-31`;
 		return baseBuilder.findAll({
 			where: and(
 				eq(windowCleaningJob.userId, userId),

--- a/src/lib/utils/dates.test.ts
+++ b/src/lib/utils/dates.test.ts
@@ -4,16 +4,17 @@ import {
 	extractDateFromTimestamp,
 	formatDateForStorage,
 	formatLocalTimestamp,
+	formatTime12h,
 	getCalendarYearMonthsRange,
 	getCurrentUTCTimestamp,
-	getMonthProgress,
 	getMonthDateRange,
+	getMonthProgress,
 	getMonthRangeFromUrl,
 	getMonthYearFromUrl,
 	getPreviousMonthsRange,
 	getTodayDate,
-	getYearProgress,
 	getYearDateRange,
+	getYearProgress,
 	padMonth
 } from './dates';
 
@@ -464,6 +465,52 @@ describe('Date Utilities - Local Timezone Storage', () => {
 				unit: 'day'
 			});
 			expect(progress.percentage).toBe(50);
+		});
+	});
+
+	describe('formatTime12h', () => {
+		it('converts midnight (00:00) to 12:00 AM', () => {
+			expect(formatTime12h('00:00')).toBe('12:00 AM');
+		});
+
+		it('converts noon (12:00) to 12:00 PM', () => {
+			expect(formatTime12h('12:00')).toBe('12:00 PM');
+		});
+
+		it('converts afternoon hour (13:05) to 1:05 PM', () => {
+			expect(formatTime12h('13:05')).toBe('1:05 PM');
+		});
+
+		it('converts morning hour (09:30) to 9:30 AM', () => {
+			expect(formatTime12h('09:30')).toBe('9:30 AM');
+		});
+
+		it('converts end of day (23:59) to 11:59 PM', () => {
+			expect(formatTime12h('23:59')).toBe('11:59 PM');
+		});
+
+		it('pads single-digit minutes (08:05)', () => {
+			expect(formatTime12h('08:05')).toBe('8:05 AM');
+		});
+
+		it('handles HH:MM:SS format using only HH and MM', () => {
+			expect(formatTime12h('14:30:00')).toBe('2:30 PM');
+		});
+
+		it('returns null for null input', () => {
+			expect(formatTime12h(null)).toBeNull();
+		});
+
+		it('returns null for undefined input', () => {
+			expect(formatTime12h(undefined)).toBeNull();
+		});
+
+		it('returns null for empty string', () => {
+			expect(formatTime12h('')).toBeNull();
+		});
+
+		it('returns null for invalid non-time input', () => {
+			expect(formatTime12h('not-a-time')).toBeNull();
 		});
 	});
 

--- a/src/lib/utils/dates.ts
+++ b/src/lib/utils/dates.ts
@@ -134,7 +134,20 @@ export function getCurrentUTCTimestamp(): string {
 }
 
 /**
- * Pad month number with leading zero
+ * Format a time string (HH:MM or HH:MM:SS) to 12-hour format
+ * @param time - Time string in 24h format (e.g. "14:30")
+ * @returns Formatted time string (e.g. "2:30 PM"), or null if input is null/undefined
+ */
+export function formatTime12h(time: string | null | undefined): string | null {
+	if (!time) return null;
+	const [h, m] = time.split(':').map(Number);
+	const ampm = h >= 12 ? 'PM' : 'AM';
+	const h12 = h % 12 || 12;
+	return `${h12}:${String(m).padStart(2, '0')} ${ampm}`;
+}
+
+/**
+ * Pad month number with leading zero for consistent formatting
  * @param month - Month number (1-12)
  * @returns Padded month string (e.g., "03" for March)
  */

--- a/src/lib/utils/dates.ts
+++ b/src/lib/utils/dates.ts
@@ -136,11 +136,20 @@ export function getCurrentUTCTimestamp(): string {
 /**
  * Format a time string (HH:MM or HH:MM:SS) to 12-hour format
  * @param time - Time string in 24h format (e.g. "14:30")
- * @returns Formatted time string (e.g. "2:30 PM"), or null if input is null/undefined
+ * @returns Formatted time string (e.g. "2:30 PM"), or null if input is null/undefined or invalid
  */
 export function formatTime12h(time: string | null | undefined): string | null {
 	if (!time) return null;
-	const [h, m] = time.split(':').map(Number);
+
+	const parts = time.split(':');
+	if (parts.length !== 2 && parts.length !== 3) return null;
+	const [hourPart, minutePart] = parts;
+	const h = Number(hourPart);
+	const m = Number(minutePart);
+	if (!Number.isFinite(h) || !Number.isFinite(m)) return null;
+	if (!Number.isInteger(h) || !Number.isInteger(m)) return null;
+	if (h < 0 || h > 23 || m < 0 || m > 59) return null;
+
 	const ampm = h >= 12 ? 'PM' : 'AM';
 	const h12 = h % 12 || 12;
 	return `${h12}:${String(m).padStart(2, '0')} ${ampm}`;

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -446,6 +446,13 @@
 				<Checkbox bind:checked={showOverBudgetOnly} />
 				Over budget only
 			</label>
+			{#if showOverBudgetOnly}
+				<span
+					class="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive"
+				>
+					{visibleCategories.length} over budget
+				</span>
+			{/if}
 		</div>
 		<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
 			{#each visibleCategories as category (category.id)}

--- a/src/routes/(app)/window-cleaning/+page.server.ts
+++ b/src/routes/(app)/window-cleaning/+page.server.ts
@@ -14,7 +14,7 @@ import { windowCleaningCustomerQueries, windowCleaningJobQueries } from '$lib/se
 import { windowCleaningCustomer, windowCleaningJob } from '$lib/server/db/schema';
 import { withAuditFieldsForUpdate } from '$lib/server/db/utils';
 import { logger } from '$lib/server/logger';
-import { getCurrentUTCTimestamp, formatDateForStorage } from '$lib/utils/dates';
+import { formatDateForStorage, getCurrentUTCTimestamp } from '$lib/utils/dates';
 
 import type { PageServerLoad } from './$types';
 
@@ -47,6 +47,9 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const jobsThisYear = allJobs.filter((j) => j.jobDate.startsWith(String(currentYear)));
 	const earnedThisYear = jobsThisYear.reduce((sum, j) => sum + j.amountCharged + j.tip, 0);
 
+	const jobsLastYear = allJobs.filter((j) => j.jobDate.startsWith(String(currentYear - 1)));
+	const earnedLastYear = jobsLastYear.reduce((sum, j) => sum + j.amountCharged + j.tip, 0);
+
 	const customerForm = await superValidate(zod4(windowCleaningCustomerSchema));
 	const jobForm = await superValidate(zod4(windowCleaningJobSchema));
 
@@ -56,6 +59,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 		jobsThisMonthCount: jobsThisMonth.length,
 		earnedThisMonth,
 		earnedThisYear,
+		earnedLastYear,
 		customerForm,
 		jobForm
 	};

--- a/src/routes/(app)/window-cleaning/+page.svelte
+++ b/src/routes/(app)/window-cleaning/+page.svelte
@@ -17,7 +17,7 @@
 		windowCleaningCustomerSchema,
 		windowCleaningJobSchema
 	} from '$lib/formSchemas/windowCleaning';
-	import { formatLocalTimestamp } from '$lib/utils/dates';
+	import { formatLocalTimestamp, formatTime12h } from '$lib/utils/dates';
 
 	import { columns } from './columns';
 
@@ -30,6 +30,7 @@
 			jobsThisMonthCount: number;
 			earnedThisMonth: number;
 			earnedThisYear: number;
+			earnedLastYear: number;
 			customerForm: SuperValidated<z.infer<typeof windowCleaningCustomerSchema>>;
 			jobForm: SuperValidated<z.infer<typeof windowCleaningJobSchema>>;
 		};
@@ -129,6 +130,18 @@
 				<p class="text-2xl font-bold text-green-600 dark:text-green-400">
 					{currencyFormatter.format(data.earnedThisYear)}
 				</p>
+				{#if data.earnedLastYear > 0}
+					{@const diff = data.earnedThisYear - data.earnedLastYear}
+					{@const pct = Math.round(Math.abs(diff / data.earnedLastYear) * 100)}
+					<p
+						class="mt-1 text-xs {diff >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-500'}"
+					>
+						{diff >= 0 ? '▲' : '▼'}
+						{pct}% vs {new Date().getFullYear() - 1} ({currencyFormatter.format(
+							data.earnedLastYear
+						)})
+					</p>
+				{/if}
 			</CardContent>
 		</Card>
 	</div>
@@ -245,7 +258,7 @@
 								{#each selectedCustomerJobs as job (job.id)}
 									<Table.Row>
 										<Table.Cell class="text-sm">{formatLocalTimestamp(job.jobDate)}</Table.Cell>
-										<Table.Cell class="text-sm">{job.jobTime ?? '—'}</Table.Cell>
+										<Table.Cell class="text-sm">{formatTime12h(job.jobTime) ?? '—'}</Table.Cell>
 										<Table.Cell class="text-sm">
 											{job.durationHours != null ? `${job.durationHours}h` : '—'}
 										</Table.Cell>

--- a/src/routes/(app)/window-cleaning/columns.ts
+++ b/src/routes/(app)/window-cleaning/columns.ts
@@ -24,10 +24,10 @@ export const columns: ColumnDef<WindowCleaningCustomerWithStats>[] = [
 			})
 	},
 	{
-		accessorKey: 'city',
+		accessorKey: 'address',
 		header: ({ column }) =>
 			renderComponent(DataTableSortButton, {
-				columnName: 'City',
+				columnName: 'Address',
 				onclick: column.getToggleSortingHandler()
 			})
 	},
@@ -35,16 +35,6 @@ export const columns: ColumnDef<WindowCleaningCustomerWithStats>[] = [
 		accessorKey: 'phoneNumber',
 		header: 'Phone',
 		cell: ({ row }) => row.original.phoneNumber || '—'
-	},
-	{
-		id: 'jobCount',
-		header: ({ column }) =>
-			renderComponent(DataTableSortButton, {
-				columnName: 'Jobs',
-				onclick: column.getToggleSortingHandler()
-			}),
-		accessorFn: (row) => row.jobs.length,
-		cell: ({ row }) => row.original.jobs.length
 	},
 	{
 		id: 'lastJobDate',
@@ -56,6 +46,19 @@ export const columns: ColumnDef<WindowCleaningCustomerWithStats>[] = [
 		accessorFn: (row) => row.lastJobDate ?? '',
 		cell: ({ row }) =>
 			row.original.lastJobDate ? formatLocalTimestamp(row.original.lastJobDate) : '—'
+	},
+	{
+		id: 'lastCharged',
+		header: 'Last Charged',
+		cell: ({ row }) => {
+			const latestJob = row.original.jobs[0];
+			if (!latestJob) return '—';
+			const amountSnippet = createRawSnippet<[string]>((getAmount) => {
+				const amount = getAmount();
+				return { render: () => `<div class="text-right">${amount}</div>` };
+			});
+			return renderSnippet(amountSnippet, currencyFormatter.format(latestJob.amountCharged));
+		}
 	},
 	{
 		id: 'totalEarned',

--- a/src/routes/(app)/window-cleaning/jobs/+page.server.ts
+++ b/src/routes/(app)/window-cleaning/jobs/+page.server.ts
@@ -10,19 +10,24 @@ import { getDb } from '$lib/server/db';
 import { windowCleaningJobQueries } from '$lib/server/db/queries';
 import { windowCleaningJob } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logger';
-import { getMonthRangeFromUrl, formatDateForStorage } from '$lib/utils/dates';
+import { formatDateForStorage } from '$lib/utils/dates';
 
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url, locals }) => {
 	const userId = locals.user!.id;
-	const { month, year } = getMonthRangeFromUrl(url);
+	const currentYear = new Date().getFullYear();
+	const selectedYear = Number(url.searchParams.get('year')) || currentYear;
 
-	const jobs = await windowCleaningJobQueries.findByMonth(userId, month, year);
+	const [jobs, jobsLastYear] = await Promise.all([
+		windowCleaningJobQueries.findByYear(userId, selectedYear),
+		windowCleaningJobQueries.findByYear(userId, selectedYear - 1)
+	]);
 
 	const totalCharged = jobs.reduce((sum, j) => sum + j.amountCharged, 0);
 	const totalTips = jobs.reduce((sum, j) => sum + j.tip, 0);
 	const totalEarned = totalCharged + totalTips;
+	const earnedLastYear = jobsLastYear.reduce((sum, j) => sum + j.amountCharged + j.tip, 0);
 
 	const jobForm = await superValidate(zod4(windowCleaningJobSchema));
 
@@ -31,6 +36,7 @@ export const load: PageServerLoad = async ({ url, locals }) => {
 		totalCharged,
 		totalTips,
 		totalEarned,
+		earnedLastYear,
 		jobCount: jobs.length,
 		jobForm
 	};

--- a/src/routes/(app)/window-cleaning/jobs/+page.server.ts
+++ b/src/routes/(app)/window-cleaning/jobs/+page.server.ts
@@ -17,7 +17,12 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async ({ url, locals }) => {
 	const userId = locals.user!.id;
 	const currentYear = new Date().getFullYear();
-	const selectedYear = Number(url.searchParams.get('year')) || currentYear;
+	const yearParam = url.searchParams.get('year');
+	const parsedYear = yearParam ? Number.parseInt(yearParam, 10) : Number.NaN;
+	const selectedYear =
+		Number.isSafeInteger(parsedYear) && parsedYear >= 1900 && parsedYear <= 9999
+			? parsedYear
+			: currentYear;
 
 	const [jobs, jobsLastYear] = await Promise.all([
 		windowCleaningJobQueries.findByYear(userId, selectedYear),

--- a/src/routes/(app)/window-cleaning/jobs/+page.svelte
+++ b/src/routes/(app)/window-cleaning/jobs/+page.svelte
@@ -5,9 +5,9 @@
 
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
-	import MonthYearSwitcher from '$lib/components/MonthYearSwitcher.svelte';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import DataTable from '$lib/components/ui/data-table/data-table.svelte';
+	import YearSwitcher from '$lib/components/YearSwitcher.svelte';
 	import type { windowCleaningJobSchema } from '$lib/formSchemas/windowCleaning';
 
 	import { columns } from './columns';
@@ -20,6 +20,7 @@
 			totalCharged: number;
 			totalTips: number;
 			totalEarned: number;
+			earnedLastYear: number;
 			jobCount: number;
 			jobForm: SuperValidated<z.infer<typeof windowCleaningJobSchema>>;
 		};
@@ -31,14 +32,12 @@
 	setContext('jobForm', data.jobForm);
 
 	const currentDate = new Date();
-	const defaultMonth = currentDate.getMonth() + 1;
 	const defaultYear = currentDate.getFullYear();
 
-	let selectedMonth = $derived(Number(page.url.searchParams.get('month')) || defaultMonth);
 	let selectedYear = $derived(Number(page.url.searchParams.get('year')) || defaultYear);
 
-	function onMonthYearChange(month: number, year: number) {
-		goto(`/window-cleaning/jobs?month=${month}&year=${year}`, {
+	function onYearChange(year: number) {
+		goto(`/window-cleaning/jobs?year=${year}`, {
 			keepFocus: true,
 			replaceState: true
 		});
@@ -61,13 +60,9 @@
 		<p class="mt-1 text-muted-foreground">Complete job history across all customers</p>
 	</div>
 
-	<!-- Month Selector -->
+	<!-- Year Selector -->
 	<div class="mb-4">
-		<MonthYearSwitcher
-			currentMonth={selectedMonth}
-			currentYear={selectedYear}
-			onMonthChange={onMonthYearChange}
-		/>
+		<YearSwitcher currentYear={selectedYear} {onYearChange} />
 	</div>
 
 	<!-- Stats Row -->
@@ -96,6 +91,16 @@
 				<p class="text-2xl font-bold text-green-600 dark:text-green-400">
 					{currencyFormatter.format(data.totalEarned)}
 				</p>
+				{#if data.earnedLastYear > 0}
+					{@const diff = data.totalEarned - data.earnedLastYear}
+					{@const pct = Math.round(Math.abs(diff / data.earnedLastYear) * 100)}
+					<p
+						class="mt-1 text-xs {diff >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-500'}"
+					>
+						{diff >= 0 ? '▲' : '▼'}
+						{pct}% vs {selectedYear - 1} ({currencyFormatter.format(data.earnedLastYear)})
+					</p>
+				{/if}
 			</CardContent>
 		</Card>
 	</div>
@@ -106,7 +111,7 @@
 	{:else}
 		<Card>
 			<CardContent class="py-12 text-center">
-				<p class="text-muted-foreground">No jobs found for this month.</p>
+				<p class="text-muted-foreground">No jobs found for this year.</p>
 			</CardContent>
 		</Card>
 	{/if}

--- a/src/routes/(app)/window-cleaning/jobs/+page.svelte
+++ b/src/routes/(app)/window-cleaning/jobs/+page.svelte
@@ -57,7 +57,7 @@
 	<!-- Header -->
 	<div class="mb-6">
 		<h1 class="text-3xl font-bold tracking-tight">All Jobs</h1>
-		<p class="mt-1 text-muted-foreground">Complete job history across all customers</p>
+		<p class="mt-1 text-muted-foreground">Jobs for {selectedYear} across all customers</p>
 	</div>
 
 	<!-- Year Selector -->

--- a/src/routes/(app)/window-cleaning/jobs/+page.svelte
+++ b/src/routes/(app)/window-cleaning/jobs/+page.svelte
@@ -34,7 +34,17 @@
 	const currentDate = new Date();
 	const defaultYear = currentDate.getFullYear();
 
-	let selectedYear = $derived(Number(page.url.searchParams.get('year')) || defaultYear);
+	function parseSelectedYear(searchParam: string | null, fallbackYear: number): number {
+		if (searchParam === null) {
+			return fallbackYear;
+		}
+
+		const parsedYear = Number.parseInt(searchParam, 10);
+
+		return Number.isFinite(parsedYear) ? parsedYear : fallbackYear;
+	}
+
+	let selectedYear = $derived(parseSelectedYear(page.url.searchParams.get('year'), defaultYear));
 
 	function onYearChange(year: number) {
 		goto(`/window-cleaning/jobs?year=${year}`, {

--- a/src/routes/(app)/window-cleaning/jobs/columns.ts
+++ b/src/routes/(app)/window-cleaning/jobs/columns.ts
@@ -44,11 +44,6 @@ export const columns: ColumnDef<WindowCleaningJob>[] = [
 		cell: ({ row }) => row.original.customer?.name ?? '—'
 	},
 	{
-		accessorKey: 'jobTime',
-		header: 'Time',
-		cell: ({ row }) => row.original.jobTime ?? '—'
-	},
-	{
 		accessorKey: 'durationHours',
 		header: ({ column }) =>
 			renderComponent(DataTableSortButton, {
@@ -56,6 +51,11 @@ export const columns: ColumnDef<WindowCleaningJob>[] = [
 				onclick: column.getToggleSortingHandler()
 			}),
 		cell: ({ row }) => (row.original.durationHours == null ? '—' : `${row.original.durationHours}h`)
+	},
+	{
+		accessorKey: 'notes',
+		header: 'Notes',
+		cell: ({ row }) => row.original.notes ?? '—'
 	},
 	{
 		accessorKey: 'amountCharged',


### PR DESCRIPTION
Introduce 12-hour time formatting for job times and implement a YearSwitcher component to enhance the display of window cleaning job data, allowing users to switch between years for better data analysis. Update queries to support yearly data retrieval.