### PR TITLE
Add MonthlyNetSavingsCard component and refactor total net display

### DIFF
--- a/src/lib/components/MonthlyNetSavingsCard.svelte
+++ b/src/lib/components/MonthlyNetSavingsCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { TimeRangeInOutData } from '$lib';
 	import * as Card from '$lib/components/ui/card/index.js';
-	import { formatCurrency } from '$lib/utils';
+	import { cn, formatCurrency } from '$lib/utils';
 
 	interface Props {
 		chartData: TimeRangeInOutData[];
@@ -54,7 +54,10 @@
 							>
 							<td class="pt-2.5 text-right font-bold tabular-nums">{formatCurrency(totalSpent)}</td>
 							<td
-								class={`pt-2.5 text-right font-bold tabular-nums ${totalNet >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'}`}
+								class={cn(
+									'pt-2.5 text-right font-bold tabular-nums',
+									totalNet >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'
+								)}
 							>
 								{totalNet >= 0 ? '+' : ''}{formatCurrency(totalNet)}
 							</td>

--- a/src/lib/components/MonthlyNetSavingsCard.svelte
+++ b/src/lib/components/MonthlyNetSavingsCard.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import type { TimeRangeInOutData } from '$lib';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { formatCurrency } from '$lib/utils';
+
+	interface Props {
+		chartData: TimeRangeInOutData[];
+	}
+
+	let { chartData }: Props = $props();
+
+	let totalIncome = $derived(chartData.reduce((sum, d) => sum + d.in, 0));
+	let totalSpent = $derived(chartData.reduce((sum, d) => sum + d.out, 0));
+	let totalNet = $derived(totalIncome - totalSpent);
+</script>
+
+<Card.Root class="shadow-xs">
+	<Card.Header class="pb-3">
+		<Card.Title class="text-base font-medium text-muted-foreground">Net Savings</Card.Title>
+	</Card.Header>
+	<Card.Content>
+		{#if chartData.length === 0}
+			<p class="text-sm text-muted-foreground">No data available.</p>
+		{:else}
+			<div class="overflow-x-auto">
+				<table class="w-full text-sm">
+					<thead>
+						<tr class="border-b text-left text-muted-foreground">
+							<th class="pb-2 font-medium">Month</th>
+							<th class="pb-2 text-right font-medium">Income</th>
+							<th class="pb-2 text-right font-medium">Spent</th>
+							<th class="pb-2 text-right font-medium">Net</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each chartData as row (row.month)}
+							{@const net = row.in - row.out}
+							<tr class="border-b border-border/50 last:border-0">
+								<td class="py-2.5">{row.month}</td>
+								<td class="py-2.5 text-right tabular-nums">{formatCurrency(row.in)}</td>
+								<td class="py-2.5 text-right tabular-nums">{formatCurrency(row.out)}</td>
+								<td
+									class={`py-2.5 text-right font-medium tabular-nums ${net >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'}`}
+								>
+									{net >= 0 ? '+' : ''}{formatCurrency(net)}
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+					<tfoot>
+						<tr class="border-t-2 border-border">
+							<td class="pt-2.5 font-bold">Total</td>
+							<td class="pt-2.5 text-right font-bold tabular-nums">{formatCurrency(totalIncome)}</td
+							>
+							<td class="pt-2.5 text-right font-bold tabular-nums">{formatCurrency(totalSpent)}</td>
+							<td
+								class={`pt-2.5 text-right font-bold tabular-nums ${totalNet >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'}`}
+							>
+								{totalNet >= 0 ? '+' : ''}{formatCurrency(totalNet)}
+							</td>
+						</tr>
+					</tfoot>
+				</table>
+			</div>
+		{/if}
+	</Card.Content>
+</Card.Root>

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -12,6 +12,7 @@
 	import KpiSparklineCard from '$lib/components/KpiSparklineCard.svelte';
 	import MonthlyCategoryChart from '$lib/components/MonthlyCategoryChart.svelte';
 	import MonthlyBudgetSummaryCard from '$lib/components/MonthlyBudgetSummaryCard.svelte';
+	import MonthlyNetSavingsCard from '$lib/components/MonthlyNetSavingsCard.svelte';
 	import MonthlyNetflowChart from '$lib/components/MonthlyNetflowChart.svelte';
 	import RecurringExpensesCard from '$lib/components/RecurringExpensesCard.svelte';
 	import SpendingBreakdownChart from '$lib/components/SpendingBreakdownChart.svelte';
@@ -565,6 +566,11 @@
 					{ytdNet >= 0 ? '+' : ''}{formatCurrency(ytdNet)}
 				</p>
 			</div>
+		</div>
+
+		<!-- Net Savings table (yearly) -->
+		<div class="mb-6">
+			<MonthlyNetSavingsCard chartData={data.timeRangeData || []} />
 		</div>
 
 		<!-- Trend charts row (yearly) -->


### PR DESCRIPTION
This pull request introduces a new `MonthlyNetSavingsCard` component to the dashboard, providing a detailed table of monthly net savings (income, spent, and net) with totals and color-coded values. The component is integrated into the dashboard page to display yearly net savings data.

**New Feature: Net Savings Table**

* Added the `MonthlyNetSavingsCard` Svelte component, which displays a table of monthly income, spent, and net savings, including totals and conditional formatting for positive/negative values.
* Integrated `MonthlyNetSavingsCard` into the dashboard page by importing it and rendering it with yearly data. [[1]](diffhunk://#diff-197275177e5d34b1af2111b28c641d7de5baef6c93d794954b1d9a04d6dc0ecdR15) [[2]](diffhunk://#diff-197275177e5d34b1af2111b28c641d7de5baef6c93d794954b1d9a04d6dc0ecdR571-R575)