### PR TITLE
Implement global transaction search functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4741,9 +4741,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.59.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.59.1.tgz",
-			"integrity": "sha512-d8OON70AphLdDesuTIl//M2O6fRTIicX8aYv8vhCiYEhTTI2OboKqey0Hu1A4VFhqwgqtq0vKDmPFGkw8kKmgw==",
+			"version": "2.60.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.60.1.tgz",
+			"integrity": "sha512-mQjlkNo+rJvpln7V2IGY2j99BqhcFbS4UN0AQNKNYfhBAFZTuCDAdW3a1sgf330mvtNvsBXn3HpAhcmvdJTcIQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
@@ -4751,7 +4751,7 @@
 				"@types/cookie": "^0.6.0",
 				"acorn": "^8.14.1",
 				"cookie": "^0.6.0",
-				"devalue": "^5.6.4",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
@@ -6765,9 +6765,9 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
-			"integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+			"integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
 			"license": "MIT"
 		},
 		"node_modules/diff": {
@@ -7426,9 +7426,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.355",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
-			"integrity": "sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==",
+			"version": "1.5.356",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.356.tgz",
+			"integrity": "sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==",
 			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
@@ -8217,9 +8217,9 @@
 			}
 		},
 		"node_modules/knip": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/knip/-/knip-6.13.1.tgz",
-			"integrity": "sha512-hvSnb+YDpDWW1LXub4U0JFfkQhscwgInWuQOv99WTutPZavf1cEP3GwxzEzO2JJpGI9yATk6l0jPLY1V3fp1sQ==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/knip/-/knip-6.14.0.tgz",
+			"integrity": "sha512-yEI9ysdGQ3h77gLObvovH0KUYs6ITtJ1f6owmXRalOO32TbolYvHY7Z+2AEOXqw0ZWeh9219/agh2K/GmtfsxQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8499,9 +8499,9 @@
 			]
 		},
 		"node_modules/libphonenumber-js": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.1.tgz",
-			"integrity": "sha512-GEw0GLL7YUUA6nv21IsCvVjtI5Ejn84sjbdfQ9KxdbqEVOk1PZh7xejn01EEiniKw+dBeCfim+8MGeuvVuE2BA==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.2.tgz",
+			"integrity": "sha512-S3kmBrptp3yRTm83NUcHy9g1vbwiWMzI8WvY22+koBJ6zkRteLnedBL2VX0MIAGwx2yiyxX4J85pceZyQ6ffgg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true
@@ -10501,9 +10501,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.55.6",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.6.tgz",
-			"integrity": "sha512-1Q1UABN+Ga+Dky+Q9HdPaYtbQQSVKgy7se0cUMDj4Y8eR8ezLuSeu6qW7aRORuCrtGyFyJnjRTuy0GTLwLhieA==",
+			"version": "5.55.7",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
+			"integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
@@ -10515,7 +10515,7 @@
 				"aria-query": "5.3.1",
 				"axobject-query": "^4.1.0",
 				"clsx": "^2.1.1",
-				"devalue": "^5.6.4",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.1",
 				"esrap": "^2.2.4",
 				"is-reference": "^3.0.3",

--- a/src/lib/server/db/queries/factory.ts
+++ b/src/lib/server/db/queries/factory.ts
@@ -17,6 +17,7 @@ export function createQueryBuilder<_TTable, TReturn = _TTable>(
 			where?: SQL;
 			orderBy?: SQL[];
 			with?: Record<string, boolean>;
+			limit?: number;
 		}): Promise<TReturn[]> => {
 			const db = getDb();
 			// Type assertion needed due to dynamic table name access
@@ -24,7 +25,8 @@ export function createQueryBuilder<_TTable, TReturn = _TTable>(
 			return (db.query as any)[config.tableName].findMany({
 				with: options?.with ?? config.defaultRelations,
 				where: options?.where,
-				orderBy: options?.orderBy ?? config.defaultOrderBy
+				orderBy: options?.orderBy ?? config.defaultOrderBy,
+				limit: options?.limit
 			}) as Promise<TReturn[]>;
 		},
 

--- a/src/lib/server/db/queries/transactions.test.ts
+++ b/src/lib/server/db/queries/transactions.test.ts
@@ -12,6 +12,7 @@ vi.mock('drizzle-orm', () => ({
 	eq: (field: unknown, value: unknown) => ({ type: 'eq', field, value }),
 	isNotNull: (field: unknown) => ({ type: 'isNotNull', field }),
 	ne: (field: unknown, value: unknown) => ({ type: 'ne', field, value }),
+	or: (...conditions: unknown[]) => ({ type: 'or', conditions }),
 	sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
 		type: 'sql',
 		text: strings.join('?'),
@@ -23,7 +24,9 @@ vi.mock('../schema', () => ({
 	transaction: {
 		date: 'transaction.date',
 		categoryId: 'transaction.category_id',
-		gstAmount: 'transaction.gst_amount'
+		gstAmount: 'transaction.gst_amount',
+		payee: 'transaction.payee',
+		notes: 'transaction.notes'
 	}
 }));
 
@@ -106,5 +109,82 @@ describe('transactionQueries', () => {
 		expect(call).toBeDefined();
 		const arg = call?.[0] as unknown as { where: { conditions: unknown[] } };
 		expect(arg.where.conditions).toHaveLength(3);
+	});
+
+	describe('search', () => {
+		type SqlCondition = { type: string; text: string; values: unknown[] };
+		type OrWhere = { type: string; conditions: SqlCondition[] };
+
+		function getWhere() {
+			const call = mockState.findAll.mock.lastCall;
+			expect(call).toBeDefined();
+			return (call![0] as unknown as { where: OrWhere }).where;
+		}
+
+		it('builds an OR condition spanning payee and notes columns', async () => {
+			await transactionQueries.search('coffee');
+
+			const where = getWhere();
+			expect(where.type).toBe('or');
+			expect(where.conditions).toHaveLength(2);
+		});
+
+		it('targets the payee column first and notes column second', async () => {
+			await transactionQueries.search('coffee');
+
+			const where = getWhere();
+			expect(where.conditions[0].values[0]).toBe('transaction.payee');
+			expect(where.conditions[1].values[0]).toBe('transaction.notes');
+		});
+
+		it('wraps the search term in % wildcards for a contains match', async () => {
+			await transactionQueries.search('coffee');
+
+			const where = getWhere();
+			expect(where.conditions[0].values[1]).toBe('%coffee%');
+			expect(where.conditions[1].values[1]).toBe('%coffee%');
+		});
+
+		it('includes an ESCAPE clause in both SQL conditions', async () => {
+			await transactionQueries.search('coffee');
+
+			const where = getWhere();
+			for (const condition of where.conditions) {
+				expect(condition.type).toBe('sql');
+				expect(condition.text).toContain('ESCAPE');
+			}
+		});
+
+		it('escapes % to prevent wildcard injection', async () => {
+			await transactionQueries.search('100%off');
+
+			const where = getWhere();
+			expect(where.conditions[0].values[1]).toBe('%100\\%off%');
+			expect(where.conditions[1].values[1]).toBe('%100\\%off%');
+		});
+
+		it('escapes _ to prevent single-character wildcard injection', async () => {
+			await transactionQueries.search('a_b');
+
+			const where = getWhere();
+			expect(where.conditions[0].values[1]).toBe('%a\\_b%');
+			expect(where.conditions[1].values[1]).toBe('%a\\_b%');
+		});
+
+		it('escapes backslashes to prevent corruption of the LIKE escape sequence', async () => {
+			await transactionQueries.search('a\\b');
+
+			const where = getWhere();
+			expect(where.conditions[0].values[1]).toBe('%a\\\\b%');
+			expect(where.conditions[1].values[1]).toBe('%a\\\\b%');
+		});
+
+		it('handles all three special characters in a single query', async () => {
+			await transactionQueries.search('50%_off\\deal');
+
+			const where = getWhere();
+			expect(where.conditions[0].values[1]).toBe('%50\\%\\_off\\\\deal%');
+			expect(where.conditions[1].values[1]).toBe('%50\\%\\_off\\\\deal%');
+		});
 	});
 });

--- a/src/lib/server/db/queries/transactions.ts
+++ b/src/lib/server/db/queries/transactions.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNotNull, ne, sql } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, like, ne, or, sql } from 'drizzle-orm';
 
 import type { Transaction } from '$lib/types';
 
@@ -48,6 +48,14 @@ export const transactionQueries = {
 			: eq(transaction.categoryId, categoryId);
 
 		return baseBuilder.findAll({ where });
+	},
+
+	// Search across all transactions by payee or notes (cross-month)
+	search: async (query: string): Promise<Transaction[]> => {
+		const pattern = `%${query}%`;
+		return baseBuilder.findAll({
+			where: or(like(transaction.payee, pattern), like(transaction.notes, pattern))
+		});
 	},
 
 	// Find by date range excluding a specific category (for business receipts)

--- a/src/lib/server/db/queries/transactions.ts
+++ b/src/lib/server/db/queries/transactions.ts
@@ -6,6 +6,12 @@ import { transaction } from '../schema';
 
 import { createQueryBuilder } from './factory';
 
+// Hard cap on full-text search results. Leading-wildcard LIKE patterns cannot use a
+// B-tree index, so this limits the work done per interactive query. If the table grows
+// to a scale where this bound is regularly hit, replace with an SQLite FTS5 virtual
+// table and use MATCH instead of LIKE.
+export const SEARCH_RESULT_LIMIT = 200;
+
 const baseBuilder = createQueryBuilder<typeof transaction, Transaction>({
 	tableName: 'transaction',
 	defaultRelations: { category: true, user: true },
@@ -50,17 +56,23 @@ export const transactionQueries = {
 		return baseBuilder.findAll({ where });
 	},
 
-	// Search across all transactions by payee or notes (cross-month)
+	// Search across all transactions by payee or notes (cross-month).
+	// Bounded to SEARCH_RESULT_LIMIT rows to prevent unbounded full-table scans;
+	// a leading-wildcard LIKE cannot use a B-tree index.
 	search: async (query: string): Promise<Transaction[]> => {
 		// Escape LIKE wildcards (\, %, _) so user input is treated as a literal string.
 		// The ESCAPE clause tells SQLite that \ is the escape character in the pattern.
-		const escaped = query.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+		const escaped = query
+			.replaceAll('\\', String.raw`\\`)
+			.replaceAll('%', String.raw`\%`)
+			.replaceAll('_', String.raw`\_`);
 		const pattern = `%${escaped}%`;
 		return baseBuilder.findAll({
 			where: or(
 				sql`${transaction.payee} LIKE ${pattern} ESCAPE '\\'`,
 				sql`${transaction.notes} LIKE ${pattern} ESCAPE '\\'`
-			)
+			),
+			limit: SEARCH_RESULT_LIMIT
 		});
 	},
 

--- a/src/lib/server/db/queries/transactions.ts
+++ b/src/lib/server/db/queries/transactions.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNotNull, like, ne, or, sql } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, ne, or, sql } from 'drizzle-orm';
 
 import type { Transaction } from '$lib/types';
 
@@ -52,9 +52,15 @@ export const transactionQueries = {
 
 	// Search across all transactions by payee or notes (cross-month)
 	search: async (query: string): Promise<Transaction[]> => {
-		const pattern = `%${query}%`;
+		// Escape LIKE wildcards (\, %, _) so user input is treated as a literal string.
+		// The ESCAPE clause tells SQLite that \ is the escape character in the pattern.
+		const escaped = query.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+		const pattern = `%${escaped}%`;
 		return baseBuilder.findAll({
-			where: or(like(transaction.payee, pattern), like(transaction.notes, pattern))
+			where: or(
+				sql`${transaction.payee} LIKE ${pattern} ESCAPE '\\'`,
+				sql`${transaction.notes} LIKE ${pattern} ESCAPE '\\'`
+			)
 		});
 	},
 

--- a/src/lib/server/db/queries/windowCleaningCustomers.test.ts
+++ b/src/lib/server/db/queries/windowCleaningCustomers.test.ts
@@ -18,7 +18,6 @@ vi.mock('drizzle-orm', () => ({
 vi.mock('../schema', () => ({
 	windowCleaningCustomer: {
 		name: 'wc_customer.name',
-		userId: 'wc_customer.user_id',
 		deletedAt: 'wc_customer.deleted_at',
 		id: 'wc_customer.id'
 	}
@@ -57,24 +56,14 @@ describe('windowCleaningCustomerQueries', () => {
 	});
 
 	describe('findAll', () => {
-		it('filters by userId and isNull(deletedAt)', async () => {
-			await windowCleaningCustomerQueries.findAll('user-1');
+		it('filters only by isNull(deletedAt)', async () => {
+			await windowCleaningCustomerQueries.findAll();
 
 			const arg = mockState.findAll.mock.lastCall![0] as unknown as {
-				where: { type: string; conditions: unknown[] };
+				where: { type: string; field: string };
 			};
-			expect(arg.where.type).toBe('and');
-			expect(arg.where.conditions).toHaveLength(2);
-
-			const conditions = arg.where.conditions as Array<{
-				type: string;
-				field: string;
-				value?: string;
-			}>;
-			const userCond = conditions.find((c) => c.type === 'eq');
-			const deletedCond = conditions.find((c) => c.type === 'isNull');
-			expect(userCond?.value).toBe('user-1');
-			expect(deletedCond?.field).toBe('wc_customer.deleted_at');
+			expect(arg.where.type).toBe('isNull');
+			expect(arg.where.field).toBe('wc_customer.deleted_at');
 		});
 	});
 
@@ -100,8 +89,8 @@ describe('windowCleaningCustomerQueries', () => {
 	});
 
 	describe('findById', () => {
-		it('calls findFirst with id, userId and isNull(deletedAt) conditions', async () => {
-			await windowCleaningCustomerQueries.findById('cust-1', 'user-1');
+		it('calls findFirst with id and isNull(deletedAt) conditions', async () => {
+			await windowCleaningCustomerQueries.findById('cust-1');
 
 			expect(mockState.findFirst).toHaveBeenCalledWith({
 				where: expect.objectContaining({ type: 'and' })
@@ -110,7 +99,7 @@ describe('windowCleaningCustomerQueries', () => {
 			const arg = mockState.findFirst.mock.lastCall![0] as unknown as {
 				where: { type: string; conditions: unknown[] };
 			};
-			expect(arg.where.conditions).toHaveLength(3);
+			expect(arg.where.conditions).toHaveLength(2);
 		});
 	});
 });

--- a/src/lib/server/db/queries/windowCleaningCustomers.ts
+++ b/src/lib/server/db/queries/windowCleaningCustomers.ts
@@ -16,13 +16,10 @@ const baseBuilder = createQueryBuilder<typeof windowCleaningCustomer, WindowClea
 export const windowCleaningCustomerQueries = {
 	...baseBuilder,
 
-	// Find all active (non-deleted) customers for a user
-	findAll: async (userId: string): Promise<WindowCleaningCustomer[]> => {
+	// Find all active (non-deleted) customers
+	findAll: async (): Promise<WindowCleaningCustomer[]> => {
 		return baseBuilder.findAll({
-			where: and(
-				eq(windowCleaningCustomer.userId, userId),
-				isNull(windowCleaningCustomer.deletedAt)
-			)
+			where: isNull(windowCleaningCustomer.deletedAt)
 		});
 	},
 
@@ -37,13 +34,9 @@ export const windowCleaningCustomerQueries = {
 	},
 
 	// Find a single active customer by id
-	findById: async (id: string, userId: string): Promise<WindowCleaningCustomer | undefined> => {
+	findById: async (id: string): Promise<WindowCleaningCustomer | undefined> => {
 		return baseBuilder.findFirst({
-			where: and(
-				eq(windowCleaningCustomer.id, id),
-				eq(windowCleaningCustomer.userId, userId),
-				isNull(windowCleaningCustomer.deletedAt)
-			)
+			where: and(eq(windowCleaningCustomer.id, id), isNull(windowCleaningCustomer.deletedAt))
 		});
 	}
 };

--- a/src/lib/server/db/queries/windowCleaningJobs.test.ts
+++ b/src/lib/server/db/queries/windowCleaningJobs.test.ts
@@ -18,7 +18,6 @@ vi.mock('drizzle-orm', () => ({
 vi.mock('../schema', () => ({
 	windowCleaningJob: {
 		jobDate: 'wc_job.job_date',
-		userId: 'wc_job.user_id',
 		customerId: 'wc_job.customer_id'
 	}
 }));
@@ -40,12 +39,10 @@ describe('windowCleaningJobQueries', () => {
 	});
 
 	describe('findAll', () => {
-		it('filters by userId', async () => {
-			await windowCleaningJobQueries.findAll('user-1');
+		it('fetches all jobs with no filter', async () => {
+			await windowCleaningJobQueries.findAll();
 
-			expect(mockState.findAll).toHaveBeenCalledWith({
-				where: { type: 'eq', field: 'wc_job.user_id', value: 'user-1' }
-			});
+			expect(mockState.findAll).toHaveBeenCalledWith();
 		});
 	});
 
@@ -60,19 +57,19 @@ describe('windowCleaningJobQueries', () => {
 	});
 
 	describe('findByMonth', () => {
-		it('passes a compound and clause with userId and date bounds', async () => {
-			await windowCleaningJobQueries.findByMonth('user-1', 4, 2026);
+		it('passes a compound and clause with date bounds', async () => {
+			await windowCleaningJobQueries.findByMonth(4, 2026);
 
 			const arg = mockState.findAll.mock.lastCall![0] as unknown as {
 				where: { type: string; conditions: unknown[] };
 			};
 			expect(arg.where.type).toBe('and');
-			expect(arg.where.conditions).toHaveLength(3);
+			expect(arg.where.conditions).toHaveLength(2);
 		});
 
 		it('computes correct February (non-leap year) end date', async () => {
 			const spy = vi.spyOn(mockState, 'findAll');
-			await windowCleaningJobQueries.findByMonth('u', 2, 2026);
+			await windowCleaningJobQueries.findByMonth(2, 2026);
 			const { conditions } = (
 				spy.mock.lastCall![0] as unknown as {
 					where: { conditions: Array<{ values: string[] }> };
@@ -86,7 +83,7 @@ describe('windowCleaningJobQueries', () => {
 
 		it('computes correct February (leap year) end date', async () => {
 			const spy = vi.spyOn(mockState, 'findAll');
-			await windowCleaningJobQueries.findByMonth('u', 2, 2024);
+			await windowCleaningJobQueries.findByMonth(2, 2024);
 			const { conditions } = (
 				spy.mock.lastCall![0] as unknown as {
 					where: { conditions: Array<{ values: string[] }> };
@@ -99,7 +96,7 @@ describe('windowCleaningJobQueries', () => {
 
 		it('computes correct December boundaries', async () => {
 			const spy = vi.spyOn(mockState, 'findAll');
-			await windowCleaningJobQueries.findByMonth('u', 12, 2025);
+			await windowCleaningJobQueries.findByMonth(12, 2025);
 			const { conditions } = (
 				spy.mock.lastCall![0] as unknown as {
 					where: { conditions: Array<{ values: string[] }> };
@@ -113,8 +110,8 @@ describe('windowCleaningJobQueries', () => {
 	});
 
 	describe('findByYear', () => {
-		it('passes a compound and clause with userId and full-year date range', async () => {
-			await windowCleaningJobQueries.findByYear('user-1', 2025);
+		it('passes a compound and clause with full-year date range', async () => {
+			await windowCleaningJobQueries.findByYear(2025);
 
 			const arg = mockState.findAll.mock.lastCall![0] as unknown as {
 				where: { type: string; conditions: unknown[] };
@@ -123,15 +120,15 @@ describe('windowCleaningJobQueries', () => {
 		});
 
 		it('throws for an invalid year (zero)', async () => {
-			await expect(windowCleaningJobQueries.findByYear('u', 0)).rejects.toThrow('Invalid year');
+			await expect(windowCleaningJobQueries.findByYear(0)).rejects.toThrow('Invalid year');
 		});
 
 		it('throws for a negative year', async () => {
-			await expect(windowCleaningJobQueries.findByYear('u', -1)).rejects.toThrow('Invalid year');
+			await expect(windowCleaningJobQueries.findByYear(-1)).rejects.toThrow('Invalid year');
 		});
 
 		it('throws for a year beyond 9999', async () => {
-			await expect(windowCleaningJobQueries.findByYear('u', 10000)).rejects.toThrow('Invalid year');
+			await expect(windowCleaningJobQueries.findByYear(10000)).rejects.toThrow('Invalid year');
 		});
 	});
 });

--- a/src/lib/server/db/queries/windowCleaningJobs.ts
+++ b/src/lib/server/db/queries/windowCleaningJobs.ts
@@ -15,11 +15,9 @@ const baseBuilder = createQueryBuilder<typeof windowCleaningJob, WindowCleaningJ
 export const windowCleaningJobQueries = {
 	...baseBuilder,
 
-	// Find all jobs for a user (across all customers), date-sorted
-	findAll: async (userId: string): Promise<WindowCleaningJob[]> => {
-		return baseBuilder.findAll({
-			where: eq(windowCleaningJob.userId, userId)
-		});
+	// Find all jobs across all customers, date-sorted
+	findAll: async (): Promise<WindowCleaningJob[]> => {
+		return baseBuilder.findAll();
 	},
 
 	// Find jobs for a specific customer
@@ -29,12 +27,8 @@ export const windowCleaningJobQueries = {
 		});
 	},
 
-	// Find jobs for a user within a month/year
-	findByMonth: async (
-		userId: string,
-		month: number,
-		year: number
-	): Promise<WindowCleaningJob[]> => {
+	// Find jobs within a month/year
+	findByMonth: async (month: number, year: number): Promise<WindowCleaningJob[]> => {
 		const paddedMonth = String(month).padStart(2, '0');
 		const startDate = `${year}-${paddedMonth}-01`;
 		const lastDay = new Date(year, month, 0).getDate();
@@ -42,15 +36,14 @@ export const windowCleaningJobQueries = {
 
 		return baseBuilder.findAll({
 			where: and(
-				eq(windowCleaningJob.userId, userId),
 				sql`date(${windowCleaningJob.jobDate}) >= date(${startDate})`,
 				sql`date(${windowCleaningJob.jobDate}) <= date(${endDate})`
 			)
 		});
 	},
 
-	// Find jobs for a user within a year
-	findByYear: async (userId: string, year: number): Promise<WindowCleaningJob[]> => {
+	// Find jobs within a year
+	findByYear: async (year: number): Promise<WindowCleaningJob[]> => {
 		const safeYear = Math.trunc(year);
 		if (!Number.isFinite(safeYear) || safeYear < 1 || safeYear > 9999) {
 			throw new Error(`Invalid year: ${year}`);
@@ -59,7 +52,6 @@ export const windowCleaningJobQueries = {
 		const endDate = `${safeYear}-12-31`;
 		return baseBuilder.findAll({
 			where: and(
-				eq(windowCleaningJob.userId, userId),
 				sql`date(${windowCleaningJob.jobDate}) >= date(${startDate})`,
 				sql`date(${windowCleaningJob.jobDate}) <= date(${endDate})`
 			)

--- a/src/lib/server/db/queries/windowCleaningJobs.ts
+++ b/src/lib/server/db/queries/windowCleaningJobs.ts
@@ -1,7 +1,8 @@
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, max, sql } from 'drizzle-orm';
 
 import type { WindowCleaningJob } from '$lib/types';
 
+import { getDb } from '../index';
 import { windowCleaningJob } from '../schema';
 
 import { createQueryBuilder } from './factory';
@@ -18,6 +19,21 @@ export const windowCleaningJobQueries = {
 	// Find all jobs across all customers, date-sorted
 	findAll: async (): Promise<WindowCleaningJob[]> => {
 		return baseBuilder.findAll();
+	},
+
+	// Aggregated per-customer stats via a single GROUP BY query
+	getStatsPerCustomer: async (): Promise<
+		{ customerId: string; totalEarned: number; lastJobDate: string | null }[]
+	> => {
+		const db = getDb();
+		return db
+			.select({
+				customerId: windowCleaningJob.customerId,
+				totalEarned: sql<number>`coalesce(sum(${windowCleaningJob.amountCharged} + ${windowCleaningJob.tip}), 0)`,
+				lastJobDate: max(windowCleaningJob.jobDate)
+			})
+			.from(windowCleaningJob)
+			.groupBy(windowCleaningJob.customerId);
 	},
 
 	// Find jobs for a specific customer

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -63,7 +63,7 @@ async function getGoalsWithProgress(): Promise<SavingsGoalWithProgress[]> {
 	});
 }
 
-async function loadMonthlyDashboard(url: URL, userId: string | undefined) {
+async function loadMonthlyDashboard(url: URL) {
 	const { month, year, startDate, endDate } = getMonthRangeFromUrl(url);
 
 	const [actualExpenses, plannedExpenses, recurringExpenses, incomeRecords, goalsWithProgress] =
@@ -131,13 +131,9 @@ async function loadMonthlyDashboard(url: URL, userId: string | undefined) {
 	const netflowSparkline = monthlyInOutData.map((d) => ({ month: d.month, value: d.in - d.out }));
 	const spendingSparkline = monthlyInOutData.map((d) => ({ month: d.month, value: d.out }));
 
-	let windowCleaningRevenue = 0;
-	let windowCleaningJobCount = 0;
-	if (userId) {
-		const wcJobs = await windowCleaningJobQueries.findByMonth(userId, month, year);
-		windowCleaningRevenue = wcJobs.reduce((s, j) => s + j.amountCharged + j.tip, 0);
-		windowCleaningJobCount = wcJobs.length;
-	}
+	const wcJobs = await windowCleaningJobQueries.findByMonth(month, year);
+	const windowCleaningRevenue = wcJobs.reduce((s, j) => s + j.amountCharged + j.tip, 0);
+	const windowCleaningJobCount = wcJobs.length;
 
 	return {
 		mode: 'monthly',
@@ -245,8 +241,8 @@ async function loadYearlyDashboard(url: URL) {
 	};
 }
 
-export const load: PageServerLoad = async ({ url, locals }) => {
+export const load: PageServerLoad = async ({ url }) => {
 	const mode = url.searchParams.get('mode') === 'yearly' ? 'yearly' : 'monthly';
-	if (mode === 'monthly') return loadMonthlyDashboard(url, locals.user?.id);
+	if (mode === 'monthly') return loadMonthlyDashboard(url);
 	return loadYearlyDashboard(url);
 };

--- a/src/routes/(app)/finances/transactions/+page.server.ts
+++ b/src/routes/(app)/finances/transactions/+page.server.ts
@@ -4,6 +4,7 @@ import { zod4 } from 'sveltekit-superforms/adapters';
 import { transactionSchema } from '$lib/formSchemas';
 import { createCrudActions } from '$lib/server/actions/crud-helpers';
 import { budgetQueries, transactionQueries } from '$lib/server/db/queries';
+import { SEARCH_RESULT_LIMIT } from '$lib/server/db/queries/transactions';
 import { transaction } from '$lib/server/db/schema';
 import { transactionBudgetAlertHooks } from '$lib/server/notifications/budget-threshold-alerts';
 import { formatDateForStorage, getMonthRangeFromUrl } from '$lib/utils/dates';
@@ -27,7 +28,8 @@ export const load: PageServerLoad = async ({ url }) => {
 			budgets: [],
 			categorySpending: {},
 			form,
-			searchQuery
+			searchQuery,
+			searchLimitReached: transactions.length >= SEARCH_RESULT_LIMIT
 		};
 	}
 

--- a/src/routes/(app)/finances/transactions/+page.server.ts
+++ b/src/routes/(app)/finances/transactions/+page.server.ts
@@ -14,30 +14,41 @@ export const load: PageServerLoad = async ({ url }) => {
 	// Get month, year, and date range from URL params or use current month/year
 	const { month, year, startDate, endDate } = getMonthRangeFromUrl(url);
 
+	const searchQuery = url.searchParams.get('search') ?? '';
+	const form = await superValidate(zod4(transactionSchema));
+
+	// In search mode: query across all months, skip budget data (sidebar is hidden)
+	if (searchQuery) {
+		const transactions = await transactionQueries.search(searchQuery);
+		return {
+			transactions,
+			budgets: [],
+			categorySpending: {},
+			form,
+			searchQuery
+		};
+	}
+
 	const transactions = await transactionQueries.findByDateRange(startDate, endDate);
 
 	// Load budgets for the current month/year
 	const budgets = await budgetQueries.findByMonthYear(month, year);
 
 	// Calculate spending per category
-	const categorySpending = transactions.reduce(
-		(acc, txn) => {
-			if (txn.category) {
-				const categoryId = txn.category.id;
-				acc[categoryId] = (acc[categoryId] || 0) + txn.amount;
-			}
-			return acc;
-		},
-		{} as Record<string, number>
-	);
-
-	const form = await superValidate(zod4(transactionSchema));
+	const categorySpending = transactions.reduce<Record<string, number>>((acc, txn) => {
+		if (txn.category) {
+			const categoryId = txn.category.id;
+			acc[categoryId] = (acc[categoryId] || 0) + txn.amount;
+		}
+		return acc;
+	}, {});
 
 	return {
 		transactions,
 		budgets,
 		categorySpending,
-		form
+		form,
+		searchQuery
 	};
 };
 

--- a/src/routes/(app)/finances/transactions/+page.server.ts
+++ b/src/routes/(app)/finances/transactions/+page.server.ts
@@ -14,7 +14,9 @@ export const load: PageServerLoad = async ({ url }) => {
 	// Get month, year, and date range from URL params or use current month/year
 	const { month, year, startDate, endDate } = getMonthRangeFromUrl(url);
 
-	const searchQuery = url.searchParams.get('search') ?? '';
+	// Normalize on the server regardless of what the client sends: trim whitespace and cap at
+	// the notes column max length (800 chars) so a crafted URL can't trigger an oversized query.
+	const searchQuery = (url.searchParams.get('search') ?? '').trim().slice(0, 800);
 	const form = await superValidate(zod4(transactionSchema));
 
 	// In search mode: query across all months, skip budget data (sidebar is hidden)

--- a/src/routes/(app)/finances/transactions/+page.svelte
+++ b/src/routes/(app)/finances/transactions/+page.svelte
@@ -49,13 +49,18 @@
 		searchInput = data.searchQuery ?? '';
 	});
 
-	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	// Matches the payee/notes column max lengths defined in the transaction schema (100 and 800
+	// chars respectively). Capping at the shorter of the two avoids sending oversized queries
+	// that could never match any stored value.
+	const MAX_SEARCH_QUERY_LENGTH = 100;
 
 	function onSearchInput(value: string) {
 		searchInput = value;
-		if (searchDebounce) clearTimeout(searchDebounce);
-		searchDebounce = setTimeout(() => {
-			const trimmed = value.trim().slice(0, 100);
+		if (debounceTimer) clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(() => {
+			const trimmed = value.trim().slice(0, MAX_SEARCH_QUERY_LENGTH);
 			const url = trimmed
 				? `/finances/transactions?search=${encodeURIComponent(trimmed)}&month=${selectedMonth}&year=${selectedYear}`
 				: `/finances/transactions?month=${selectedMonth}&year=${selectedYear}`;

--- a/src/routes/(app)/finances/transactions/+page.svelte
+++ b/src/routes/(app)/finances/transactions/+page.svelte
@@ -30,6 +30,7 @@
 			categorySpending: Record<string, number>;
 			form: SuperValidated<z.infer<typeof transactionSchema>>;
 			searchQuery: string;
+			searchLimitReached?: boolean;
 		};
 	}
 
@@ -69,7 +70,7 @@
 		debounceTimer = setTimeout(() => {
 			const trimmed = value.trim().slice(0, MAX_SEARCH_QUERY_LENGTH);
 			const url = trimmed
-				? `/finances/transactions?search=${encodeURIComponent(trimmed)}&month=${selectedMonth}&year=${selectedYear}`
+				? `/finances/transactions?search=${encodeURIComponent(trimmed)}`
 				: `/finances/transactions?month=${selectedMonth}&year=${selectedYear}`;
 			goto(url, { keepFocus: true, replaceState: true });
 		}, 500);
@@ -156,6 +157,7 @@
 				<Input
 					type="search"
 					placeholder="Search all transactions by payee or notes…"
+					aria-label="Search transactions"
 					class="pl-9 {data.searchQuery ? 'pr-9' : ''}"
 					value={searchInput}
 					oninput={(e) => onSearchInput(e.currentTarget.value)}
@@ -176,7 +178,8 @@
 					{data.transactions.length}
 					{data.transactions.length === 1 ? 'result' : 'results'} for "<span
 						class="font-medium text-foreground">{data.searchQuery}</span
-					>"
+					>"{#if data.searchLimitReached}
+						— showing first {data.transactions.length}; refine your search to see more{/if}
 				</p>
 			{/if}
 		</div>

--- a/src/routes/(app)/finances/transactions/+page.svelte
+++ b/src/routes/(app)/finances/transactions/+page.svelte
@@ -51,10 +51,17 @@
 
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-	// Matches the payee/notes column max lengths defined in the transaction schema (100 and 800
-	// chars respectively). Capping at the shorter of the two avoids sending oversized queries
-	// that could never match any stored value.
-	const MAX_SEARCH_QUERY_LENGTH = 100;
+	// Prevent a stale goto() from firing after the component is destroyed (e.g. the user
+	// types in the search box and navigates away before the 500 ms debounce elapses).
+	$effect(() => () => {
+		if (debounceTimer) clearTimeout(debounceTimer);
+	});
+
+	// Matches the longest searchable transaction field max length defined in the transaction
+	// schema. Payee is capped at 100 characters, but notes can be up to 800 characters, so the
+	// search query must allow up to 800 characters to avoid truncating valid note searches before
+	// they reach the server.
+	const MAX_SEARCH_QUERY_LENGTH = 800;
 
 	function onSearchInput(value: string) {
 		searchInput = value;

--- a/src/routes/(app)/finances/transactions/+page.svelte
+++ b/src/routes/(app)/finances/transactions/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import PlusIcon from '@lucide/svelte/icons/plus';
+	import SearchIcon from '@lucide/svelte/icons/search';
+	import XIcon from '@lucide/svelte/icons/x';
 	import type { SuperValidated } from 'sveltekit-superforms';
 	import type { z } from 'zod';
 
@@ -12,6 +14,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { DataTable } from '$lib/components/ui/data-table';
 	import * as Select from '$lib/components/ui/select/index.js';
+	import { Input } from '$lib/components/ui/input';
 	import { getCategoriesContext, transactionFormContext } from '$lib/contexts';
 	import type { transactionSchema } from '$lib/formSchemas';
 	import { months } from '$lib/utils';
@@ -26,6 +29,7 @@
 			budgets: Budget[];
 			categorySpending: Record<string, number>;
 			form: SuperValidated<z.infer<typeof transactionSchema>>;
+			searchQuery: string;
 		};
 	}
 
@@ -38,6 +42,33 @@
 
 	let openModal = $state<boolean>(false);
 	let loading = $state(false);
+
+	// svelte-ignore state_referenced_locally
+	let searchInput = $state(data.searchQuery ?? '');
+	$effect(() => {
+		searchInput = data.searchQuery ?? '';
+	});
+
+	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	function onSearchInput(value: string) {
+		searchInput = value;
+		if (searchDebounce) clearTimeout(searchDebounce);
+		searchDebounce = setTimeout(() => {
+			const trimmed = value.trim().slice(0, 100);
+			const url = trimmed
+				? `/finances/transactions?search=${encodeURIComponent(trimmed)}&month=${selectedMonth}&year=${selectedYear}`
+				: `/finances/transactions?month=${selectedMonth}&year=${selectedYear}`;
+			goto(url, { keepFocus: true, replaceState: true });
+		}, 500);
+	}
+
+	function clearSearch() {
+		goto(`/finances/transactions?month=${selectedMonth}&year=${selectedYear}`, {
+			keepFocus: true,
+			replaceState: true
+		});
+	}
 
 	const currentDate = new Date();
 	const defaultMonth = currentDate.getMonth() + 1;
@@ -80,35 +111,68 @@
 
 <div class="px-4 py-6 sm:px-0">
 	<div class="mb-8">
-		<div class="flex items-center justify-between gap-4">
-			<div class="hidden md:flex">
-				<MonthYearSwitcher
-					currentMonth={selectedMonth}
-					currentYear={selectedYear}
-					onMonthChange={onMonthYearChange}
+		<div class="flex flex-col gap-3">
+			<div class="flex items-center justify-between gap-4">
+				<div class="hidden md:flex">
+					<MonthYearSwitcher
+						currentMonth={selectedMonth}
+						currentYear={selectedYear}
+						onMonthChange={onMonthYearChange}
+					/>
+				</div>
+				<div class="w-full md:w-44">
+					<Select.Root type="single" value={selectedMonth.toString()} onValueChange={onMonthJump}>
+						<Select.Trigger class="w-full">
+							{months.find((m) => m.value === selectedMonth.toString())?.label || 'Jump to Month'}
+						</Select.Trigger>
+						<Select.Content>
+							<Select.Label>Jump to Month</Select.Label>
+							{#each months as month (month.value)}
+								<Select.Item value={month.value} label={month.label}>
+									{month.label}
+								</Select.Item>
+							{/each}
+						</Select.Content>
+					</Select.Root>
+				</div>
+			</div>
+			<!-- Global transaction search -->
+			<div class="relative">
+				<SearchIcon
+					class="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground"
 				/>
+				<Input
+					type="search"
+					placeholder="Search all transactions by payee or notes…"
+					class="pl-9 {data.searchQuery ? 'pr-9' : ''}"
+					value={searchInput}
+					oninput={(e) => onSearchInput(e.currentTarget.value)}
+				/>
+				{#if data.searchQuery}
+					<button
+						type="button"
+						onclick={clearSearch}
+						class="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+						aria-label="Clear search"
+					>
+						<XIcon class="h-4 w-4" />
+					</button>
+				{/if}
 			</div>
-			<div class="w-full md:w-44">
-				<Select.Root type="single" value={selectedMonth.toString()} onValueChange={onMonthJump}>
-					<Select.Trigger class="w-full">
-						{months.find((m) => m.value === selectedMonth.toString())?.label || 'Jump to Month'}
-					</Select.Trigger>
-					<Select.Content>
-						<Select.Label>Jump to Month</Select.Label>
-						{#each months as month (month.value)}
-							<Select.Item value={month.value} label={month.label}>
-								{month.label}
-							</Select.Item>
-						{/each}
-					</Select.Content>
-				</Select.Root>
-			</div>
+			{#if data.searchQuery}
+				<p class="text-sm text-muted-foreground">
+					{data.transactions.length}
+					{data.transactions.length === 1 ? 'result' : 'results'} for "<span
+						class="font-medium text-foreground">{data.searchQuery}</span
+					>"
+				</p>
+			{/if}
 		</div>
 	</div>
 
-	<div class="flex flex-col gap-6 lg:grid lg:grid-cols-4">
+	<div class="flex flex-col gap-6 {data.searchQuery ? '' : 'lg:grid lg:grid-cols-4'}">
 		<!-- Table Column (larger) -->
-		<div class="lg:col-span-3">
+		<div class={data.searchQuery ? '' : 'lg:col-span-3'}>
 			<div class="overflow-hidden rounded-lg border shadow">
 				<div class="p-6">
 					<div class="mb-4 flex items-center justify-between">
@@ -134,28 +198,30 @@
 			</div>
 		</div>
 
-		<!-- Summary Card Column -->
-		<div class="lg:col-span-1">
-			<div class="overflow-hidden rounded-lg border shadow">
-				<div class="p-6">
-					<h2 class="text-center text-2xl font-bold tracking-tight">Budget Summary</h2>
-					<div class="my-4 border-t"></div>
-					{#if sortedBudgets.length === 0}
-						<p class="text-center text-sm text-muted-foreground">No budgets set for this month</p>
-					{:else}
-						{#each sortedBudgets as budgetItem (budgetItem.id)}
-							{#if budgetItem.category}
-								<CategoryBudgetProgress
-									categoryName={budgetItem.category.name}
-									spent={data.categorySpending[budgetItem.category.id] || 0}
-									budgeted={budgetItem.amount}
-								/>
-							{/if}
-						{/each}
-					{/if}
+		<!-- Summary Card Column (hidden in search mode) -->
+		{#if !data.searchQuery}
+			<div class="lg:col-span-1">
+				<div class="overflow-hidden rounded-lg border shadow">
+					<div class="p-6">
+						<h2 class="text-center text-2xl font-bold tracking-tight">Budget Summary</h2>
+						<div class="my-4 border-t"></div>
+						{#if sortedBudgets.length === 0}
+							<p class="text-center text-sm text-muted-foreground">No budgets set for this month</p>
+						{:else}
+							{#each sortedBudgets as budgetItem (budgetItem.id)}
+								{#if budgetItem.category}
+									<CategoryBudgetProgress
+										categoryName={budgetItem.category.name}
+										spent={data.categorySpending[budgetItem.category.id] || 0}
+										budgeted={budgetItem.amount}
+									/>
+								{/if}
+							{/each}
+						{/if}
+					</div>
 				</div>
 			</div>
-		</div>
+		{/if}
 	</div>
 </div>
 

--- a/src/routes/(app)/window-cleaning/+page.server.ts
+++ b/src/routes/(app)/window-cleaning/+page.server.ts
@@ -13,29 +13,46 @@ import { withAuditFieldsForUpdate } from '$lib/server/db/utils';
 import { logger } from '$lib/server/logger';
 import { formatDateForStorage, getCurrentUTCTimestamp } from '$lib/utils/dates';
 
+import type { WindowCleaningJob } from '$lib/types';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	const [customers, allJobs] = await Promise.all([
+	const [customers, allJobs, customerStats] = await Promise.all([
 		windowCleaningCustomerQueries.findAll(),
-		windowCleaningJobQueries.findAll()
+		windowCleaningJobQueries.findAll(),
+		windowCleaningJobQueries.getStatsPerCustomer()
 	]);
 
-	// Merge job stats into each customer
+	// Build O(1) lookup maps — avoids O(customers × jobs) filter loops
+	const statsMap = new Map(customerStats.map((s) => [s.customerId, s]));
+	const jobsMap = allJobs.reduce((acc, job) => {
+		const list = acc.get(job.customerId);
+		if (list) {
+			list.push(job);
+		} else {
+			acc.set(job.customerId, [job]);
+		}
+		return acc;
+	}, new Map<string, WindowCleaningJob[]>());
+
+	const customersWithStats = customers.map((customer) => {
+		const stats = statsMap.get(customer.id);
+		const jobs = jobsMap.get(customer.id) ?? [];
+		return {
+			...customer,
+			jobs,
+			totalEarned: stats?.totalEarned ?? 0,
+			lastJobDate: stats?.lastJobDate ?? null
+		};
+	});
+
+	// Page-level summary stats
 	const now = new Date();
 	const currentMonth = now.getMonth() + 1;
 	const currentYear = now.getFullYear();
 	const monthPad = String(currentMonth).padStart(2, '0');
 	const monthPrefix = `${currentYear}-${monthPad}`;
 
-	const customersWithStats = customers.map((customer) => {
-		const jobs = allJobs.filter((j) => j.customerId === customer.id);
-		const totalEarned = jobs.reduce((sum, j) => sum + j.amountCharged + j.tip, 0);
-		const lastJobDate = jobs.length > 0 ? jobs[0].jobDate : null;
-		return { ...customer, jobs, totalEarned, lastJobDate };
-	});
-
-	// Page-level summary stats
 	const jobsThisMonth = allJobs.filter((j) => j.jobDate.startsWith(monthPrefix));
 	const earnedThisMonth = jobsThisMonth.reduce((sum, j) => sum + j.amountCharged + j.tip, 0);
 

--- a/src/routes/(app)/window-cleaning/+page.server.ts
+++ b/src/routes/(app)/window-cleaning/+page.server.ts
@@ -15,12 +15,10 @@ import { formatDateForStorage, getCurrentUTCTimestamp } from '$lib/utils/dates';
 
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ locals }) => {
-	const userId = locals.user!.id;
-
+export const load: PageServerLoad = async () => {
 	const [customers, allJobs] = await Promise.all([
-		windowCleaningCustomerQueries.findAll(userId),
-		windowCleaningJobQueries.findAll(userId)
+		windowCleaningCustomerQueries.findAll(),
+		windowCleaningJobQueries.findAll()
 	]);
 
 	// Merge job stats into each customer

--- a/src/routes/(app)/window-cleaning/jobs/+page.server.ts
+++ b/src/routes/(app)/window-cleaning/jobs/+page.server.ts
@@ -14,8 +14,7 @@ import { formatDateForStorage } from '$lib/utils/dates';
 
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ url, locals }) => {
-	const userId = locals.user!.id;
+export const load: PageServerLoad = async ({ url }) => {
 	const currentYear = new Date().getFullYear();
 	const yearParam = url.searchParams.get('year');
 	const parsedYear = yearParam ? Number.parseInt(yearParam, 10) : Number.NaN;
@@ -25,8 +24,8 @@ export const load: PageServerLoad = async ({ url, locals }) => {
 			: currentYear;
 
 	const [jobs, jobsLastYear] = await Promise.all([
-		windowCleaningJobQueries.findByYear(userId, selectedYear),
-		windowCleaningJobQueries.findByYear(userId, selectedYear - 1)
+		windowCleaningJobQueries.findByYear(selectedYear),
+		windowCleaningJobQueries.findByYear(selectedYear - 1)
 	]);
 
 	const totalCharged = jobs.reduce((sum, j) => sum + j.amountCharged, 0);


### PR DESCRIPTION
This pull request removes user-based filtering from window cleaning customer and job queries, making these queries operate across all users rather than being scoped to a specific user. It also introduces a new search feature for transactions that allows searching by payee or notes with proper SQL wildcard escaping. The associated tests are updated to reflect these changes.

**Database Query Changes:**

* Window cleaning customer and job queries (`windowCleaningCustomerQueries`, `windowCleaningJobQueries`) no longer require or filter by `userId`; all relevant methods and their tests are updated accordingly. [[1]](diffhunk://#diff-5b128e790a9c0b5e001c116f0e40e5c25dcd7c8de23fe46289e390c28b7853b4L19-R22) [[2]](diffhunk://#diff-5b128e790a9c0b5e001c116f0e40e5c25dcd7c8de23fe46289e390c28b7853b4L40-R39) [[3]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L21) [[4]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L43-R45) [[5]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L63-R72) [[6]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L89-R86) [[7]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L102-R99) [[8]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L116-R114) [[9]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L126-R131) [[10]](diffhunk://#diff-6dcf16780ef2ac9b2e3b52dbf60f8767349feba3ad03bc994ddde71f4c7656f2L18-R20) [[11]](diffhunk://#diff-6dcf16780ef2ac9b2e3b52dbf60f8767349feba3ad03bc994ddde71f4c7656f2L32-R46) [[12]](diffhunk://#diff-6dcf16780ef2ac9b2e3b52dbf60f8767349feba3ad03bc994ddde71f4c7656f2L62) [[13]](diffhunk://#diff-ceac4b51f43a4c0c1e54f54f2eda548b5570781f0266becb71e347ba79689cb3L21) [[14]](diffhunk://#diff-ceac4b51f43a4c0c1e54f54f2eda548b5570781f0266becb71e347ba79689cb3L60-R66) [[15]](diffhunk://#diff-ceac4b51f43a4c0c1e54f54f2eda548b5570781f0266becb71e347ba79689cb3L103-R93) [[16]](diffhunk://#diff-ceac4b51f43a4c0c1e54f54f2eda548b5570781f0266becb71e347ba79689cb3L113-R102)

* The dashboard loader (`+page.server.ts`) is updated to call the new user-independent window cleaning job queries, and no longer passes or checks for a user ID. [[1]](diffhunk://#diff-ef8a16b1b4477cd34c327842dbdba00cc381aa504ed88eba77d0e369f799477eL66-R66) [[2]](diffhunk://#diff-ef8a16b1b4477cd34c327842dbdba00cc381aa504ed88eba77d0e369f799477eL134-R136) [[3]](diffhunk://#diff-ef8a16b1b4477cd34c327842dbdba00cc381aa504ed88eba77d0e369f799477eL248-R246)

**Transaction Search Feature:**

* Adds a `search` method to `transactionQueries` that searches the `payee` and `notes` columns using a SQL `LIKE` pattern with proper escaping for wildcards and backslashes, and updates the schema mock and tests to support this. [[1]](diffhunk://#diff-a23fac03c6f4c8a8f35875416513a700181386be4a3542ade90fafc16eebcb93L1-R1) [[2]](diffhunk://#diff-a23fac03c6f4c8a8f35875416513a700181386be4a3542ade90fafc16eebcb93R53-R66) [[3]](diffhunk://#diff-af127fbed971b40828cc9fb833d88d78bf3c93ffd5ef936061c5ce0e3e0a6b67R15) [[4]](diffhunk://#diff-af127fbed971b40828cc9fb833d88d78bf3c93ffd5ef936061c5ce0e3e0a6b67L26-R29) [[5]](diffhunk://#diff-af127fbed971b40828cc9fb833d88d78bf3c93ffd5ef936061c5ce0e3e0a6b67R113-R189)

**Testing Updates:**

* All affected test files are updated to match the new query signatures and expected behaviors, including removal of `userId` arguments and changes in assertion logic. [[1]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L43-R45) [[2]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L63-R72) [[3]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L89-R86) [[4]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L102-R99) [[5]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L116-R114) [[6]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L126-R131) [[7]](diffhunk://#diff-ceac4b51f43a4c0c1e54f54f2eda548b5570781f0266becb71e347ba79689cb3L60-R66) [[8]](diffhunk://#diff-ceac4b51f43a4c0c1e54f54f2eda548b5570781f0266becb71e347ba79689cb3L103-R93) [[9]](diffhunk://#diff-ceac4b51f43a4c0c1e54f54f2eda548b5570781f0266becb71e347ba79689cb3L113-R102) [[10]](diffhunk://#diff-af127fbed971b40828cc9fb833d88d78bf3c93ffd5ef936061c5ce0e3e0a6b67R113-R189)

**Schema and Mock Updates:**

* Schema mocks are updated to remove `userId` fields from window cleaning customer and job mocks, and to add `payee` and `notes` to the transaction mock. [[1]](diffhunk://#diff-af127fbed971b40828cc9fb833d88d78bf3c93ffd5ef936061c5ce0e3e0a6b67L26-R29) [[2]](diffhunk://#diff-ceac4b51f43a4c0c1e54f54f2eda548b5570781f0266becb71e347ba79689cb3L21) [[3]](diffhunk://#diff-d0869c9b055d431486a7fab9e2da01cdf2a0a62a8c2877b4768016283c994c70L21)

**Drizzle ORM Mock Enhancements:**

* Adds an `or` operator to the Drizzle ORM mock to support the new transaction search feature.