### PR TITLE
Update TypeScript and related dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 			"devDependencies": {
 				"@flydotio/dockerfile": "^0.7.10",
 				"@internationalized/date": "^3.12.1",
-				"@lucide/svelte": "^1.7.0",
+				"@lucide/svelte": "^1.20.0",
 				"@sveltejs/adapter-node": "^5.4.0",
 				"@sveltejs/kit": "^2.49.2",
 				"@sveltejs/vite-plugin-svelte": "^7.0.0",
@@ -54,7 +54,7 @@
 				"tailwind-variants": "^3.2.2",
 				"tailwindcss": "^4.1.18",
 				"tw-animate-css": "^1.4.0",
-				"typescript": "^5.9.3",
+				"typescript": "^6.0.3",
 				"vite": "^8.0.13",
 				"vitest": "^4.1.6",
 				"zod": "^4.4.3"
@@ -325,9 +325,9 @@
 			}
 		},
 		"node_modules/@better-auth/core": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.16.tgz",
-			"integrity": "sha512-a0+ZNaaYYxOdFXFXmOE36TgtYN8QDzSYDozaAH0zsiWB0oyljsENyCxHJSekysISftb0rFpVXNdw525aEAOa6w==",
+			"version": "1.6.19",
+			"resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.19.tgz",
+			"integrity": "sha512-ddE3Y9MoQ8t32QSO5Y8mV7pmnDAv5LdJjX1SPWUH6JUUmuOc7YEy3B5JfXZIJbRaXFdnAitN7pHPVa5u/dYAZA==",
 			"license": "MIT",
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.39.0",
@@ -335,8 +335,8 @@
 				"zod": "^4.3.6"
 			},
 			"peerDependencies": {
-				"@better-auth/utils": "0.4.1",
-				"@better-fetch/fetch": "1.2.2",
+				"@better-auth/utils": "0.4.2",
+				"@better-fetch/fetch": "1.3.1",
 				"@cloudflare/workers-types": ">=4",
 				"@opentelemetry/api": "^1.9.0",
 				"better-call": "1.3.6",
@@ -354,13 +354,13 @@
 			}
 		},
 		"node_modules/@better-auth/drizzle-adapter": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.16.tgz",
-			"integrity": "sha512-AZjswadpR7zlQduj3fRSsu1R5ldQRR9AeFqoxXRI4colrQhevOVY+tJr8RTJv9Nh18e9FMYDXUju2GX+QWHDzg==",
+			"version": "1.6.19",
+			"resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.19.tgz",
+			"integrity": "sha512-57C9ePorPmIEez6dHuQMz3hCTkYim0lfVRIoRtX7PiVfiRFB2bjXseQwrCJfQmkgMFlkp1s/c9nKgAjc2EvAIg==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "^1.6.16",
-				"@better-auth/utils": "0.4.1",
+				"@better-auth/core": "^1.6.19",
+				"@better-auth/utils": "0.4.2",
 				"drizzle-orm": "^0.45.2"
 			},
 			"peerDependenciesMeta": {
@@ -370,13 +370,13 @@
 			}
 		},
 		"node_modules/@better-auth/kysely-adapter": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.16.tgz",
-			"integrity": "sha512-ys/feL1p6By3/rQlMZ8QTgf9K2tZAIp1p+fGqT2krIoG5r+UsH3gMkUdbHlYxLt790Bo+Njkiqt59P0BMNsi+g==",
+			"version": "1.6.19",
+			"resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.19.tgz",
+			"integrity": "sha512-DlmvllEd0nv8JL+plX3JB3WTmqDFnGFOmjmIiUDHo8R3PTAvC0ZaJq3Jk+LQLN5PyVQSUzXZKtvTQYaqRHzBaw==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "^1.6.16",
-				"@better-auth/utils": "0.4.1",
+				"@better-auth/core": "^1.6.19",
+				"@better-auth/utils": "0.4.2",
 				"kysely": "^0.28.17 || ^0.29.0"
 			},
 			"peerDependenciesMeta": {
@@ -386,23 +386,23 @@
 			}
 		},
 		"node_modules/@better-auth/memory-adapter": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.16.tgz",
-			"integrity": "sha512-8mDqe+2PMF9hUxjGNP1NOcqU1AqjUgmE8YC1HTtxa+LjnO7zsAPSxGSyo1L+7buFNLtiNyGFxccHpwOkO4/Msw==",
+			"version": "1.6.19",
+			"resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.19.tgz",
+			"integrity": "sha512-cZ8iLRG/T8Oi/CqE9FTHj3z8pIOqRsINi50trWxPNwyY/Eyb7YCljrBi0PuqgIdyVs7BWfrrtEYTpO4ddfuwEw==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "^1.6.16",
-				"@better-auth/utils": "0.4.1"
+				"@better-auth/core": "^1.6.19",
+				"@better-auth/utils": "0.4.2"
 			}
 		},
 		"node_modules/@better-auth/mongo-adapter": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.16.tgz",
-			"integrity": "sha512-JbUg/v3m9WUX94ivVdUOF8t/w2mWNBWvqYMqyWybfHQEPR8cvcqsqpfYvwg9HLBrYwhKXBS3KcJ1Rtk6gZ19Yw==",
+			"version": "1.6.19",
+			"resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.19.tgz",
+			"integrity": "sha512-8AReXqhMGiGQIPEpGbmAhh+R4g70TsAVvzwdd6Aj4q+LTSwd3tqC89TFJ4eX8KSplxm9PFBZ6g6gsRmDd7urQg==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "^1.6.16",
-				"@better-auth/utils": "0.4.1",
+				"@better-auth/core": "^1.6.19",
+				"@better-auth/utils": "0.4.2",
 				"mongodb": "^6.0.0 || ^7.0.0"
 			},
 			"peerDependenciesMeta": {
@@ -412,13 +412,13 @@
 			}
 		},
 		"node_modules/@better-auth/prisma-adapter": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.16.tgz",
-			"integrity": "sha512-2bIlA7wjBx+4N2QcM32xL/YojRuJpDvskXqT/dGYKToDIEl/7yr12cLYlqeaFLL0O0s5qNZ8jbDtlCz20eogeQ==",
+			"version": "1.6.19",
+			"resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.19.tgz",
+			"integrity": "sha512-pXZBhR7/bzJb48IUHlGMyz9SM9h1OCO5GIIuHEllJYt8MKgrjtsnXfUkwZh6pAUEIp3WxBEYMMK96bfkqHiWEg==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "^1.6.16",
-				"@better-auth/utils": "0.4.1",
+				"@better-auth/core": "^1.6.19",
+				"@better-auth/utils": "0.4.2",
 				"@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
 				"prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
 			},
@@ -432,29 +432,30 @@
 			}
 		},
 		"node_modules/@better-auth/telemetry": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.16.tgz",
-			"integrity": "sha512-A782UQvlqZBddw0j2Q6tdroHulIpMlqQh/pbw2up30drLi66jz1ttgShRmryfOLAqN4DHqteuRrSsqDDrsp/pA==",
+			"version": "1.6.19",
+			"resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.19.tgz",
+			"integrity": "sha512-bBaB6SMIsrD3WutDdm5YQ1bQyinANTimHD8RtpLWhNh/jIXvzgwVVCrDFqA256vcGC/ZRCydmtW8ZrUqNMW9Og==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "^1.6.16",
-				"@better-auth/utils": "0.4.1",
-				"@better-fetch/fetch": "1.2.2"
+				"@better-auth/core": "^1.6.19",
+				"@better-auth/utils": "0.4.2",
+				"@better-fetch/fetch": "1.3.1"
 			}
 		},
 		"node_modules/@better-auth/utils": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.1.tgz",
-			"integrity": "sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.2.tgz",
+			"integrity": "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==",
 			"license": "MIT",
 			"dependencies": {
 				"@noble/hashes": "^2.0.1"
 			}
 		},
 		"node_modules/@better-fetch/fetch": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.2.2.tgz",
-			"integrity": "sha512-xlgQcYROGFgKg5FY7ZLppFmG7rR5Hkmz7tgDuQeR79i5KhKRjr2QC9xsBG2qEGPJJjf9bxzg/NMW2hEUWs5OnA=="
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.1.tgz",
+			"integrity": "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==",
+			"license": "MIT"
 		},
 		"node_modules/@dagrejs/dagre": {
 			"version": "2.0.4",
@@ -922,9 +923,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -938,9 +939,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
 			"cpu": [
 				"arm"
 			],
@@ -954,9 +955,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
 			"cpu": [
 				"arm64"
 			],
@@ -970,9 +971,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
 			"cpu": [
 				"x64"
 			],
@@ -986,9 +987,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1002,9 +1003,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1018,9 +1019,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1034,9 +1035,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1050,9 +1051,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1066,9 +1067,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1082,9 +1083,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
 			"cpu": [
 				"ia32"
 			],
@@ -1098,9 +1099,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
 			"cpu": [
 				"loong64"
 			],
@@ -1114,9 +1115,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1130,9 +1131,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1146,9 +1147,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1162,9 +1163,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
 			"cpu": [
 				"s390x"
 			],
@@ -1178,9 +1179,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
 			"cpu": [
 				"x64"
 			],
@@ -1194,9 +1195,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1210,9 +1211,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
 			"cpu": [
 				"x64"
 			],
@@ -1226,9 +1227,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1242,9 +1243,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
 			"cpu": [
 				"x64"
 			],
@@ -1258,9 +1259,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1274,9 +1275,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1290,9 +1291,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1306,9 +1307,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
 			"cpu": [
 				"ia32"
 			],
@@ -1322,9 +1323,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
 			"cpu": [
 				"x64"
 			],
@@ -1346,9 +1347,9 @@
 			"optional": true
 		},
 		"node_modules/@fallow-cli/darwin-arm64": {
-			"version": "2.91.0",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.91.0.tgz",
-			"integrity": "sha512-srKb1BUNgGuWsFpiwtBbgu7holAEA/YtNuv0iWOHmD9bDCH944SomV2ehP7HqO9KE7D6bhFxHXoE9S5tyaPmzw==",
+			"version": "2.98.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.98.0.tgz",
+			"integrity": "sha512-tFCy1pv8aYePZewaof83bdRNWY141kuJDb5Z+zcAoh+WAEZedAUyBQ2+3mEJSURo/pe1AWccNMDt31/LJOemAA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1360,9 +1361,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/darwin-x64": {
-			"version": "2.91.0",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.91.0.tgz",
-			"integrity": "sha512-/6DrBEDtDSAltXi7Bj5UoBG6yhoUCH2gAp/XXZ6Xr2ErLz9X088q6Kw9sfIyhDNpt9mpOQ8K/nsaE7EAjZfeZg==",
+			"version": "2.98.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.98.0.tgz",
+			"integrity": "sha512-6+j4Q+guPRYWPvQr8njmb+34koBoxcGisa6zthDCV4jVqlVC2Vyc/5fmUyJtqIa+i00lnSo7K4XaWS/QAh4Tfg==",
 			"cpu": [
 				"x64"
 			],
@@ -1374,9 +1375,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/linux-arm64-gnu": {
-			"version": "2.91.0",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.91.0.tgz",
-			"integrity": "sha512-Qlr7oCxa/IydLGUWMayTWXMvud/Jzzya7ISGAv5kIoXTd4kfqHYXI88wtNEjixIjJz/KiEPgCF7lLtiGeOIcJQ==",
+			"version": "2.98.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.98.0.tgz",
+			"integrity": "sha512-fYg1hmwppTohcZnFReKiZaxJ5mG+tWnkSqONLFidkwFfr3dLie+rNqWPDM35aI+7+zwtD2ebcDSmDf48fnH01g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1388,9 +1389,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/linux-arm64-musl": {
-			"version": "2.91.0",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.91.0.tgz",
-			"integrity": "sha512-yl5q62ewqd33NzyS3g9rzetuFDAZ1oOMMcxZgXr0MTjzHymZhqfjNzUxLwAgI49w0sGJ5KXUdTfDRncvhNvpBw==",
+			"version": "2.98.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.98.0.tgz",
+			"integrity": "sha512-sDcOyYYjfFves3EGUjKooql02cb07j53OUdIeN2NKn0V9dXCeW36g31vc5ZlqDjNkmsQQkzi5J5jp/nxAbSwjw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1402,9 +1403,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/linux-x64-gnu": {
-			"version": "2.91.0",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.91.0.tgz",
-			"integrity": "sha512-iklZtyr/OD7stfI4Zj2YhrYRzDDn0rQguLolQtG2T4Is+bfDEBHSglsMSM9/7n2pPAlNAPSOkxeV+VjofzXJkg==",
+			"version": "2.98.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.98.0.tgz",
+			"integrity": "sha512-Rk95DLLufZXD3w/u6pdymOOvRotquutO0o2Nd2oYa1BWl6pHhcO3B9tbENJIZR1qY3vAS1n/BA2ZRfnL9rvwIw==",
 			"cpu": [
 				"x64"
 			],
@@ -1416,9 +1417,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/linux-x64-musl": {
-			"version": "2.91.0",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.91.0.tgz",
-			"integrity": "sha512-pFLIQ0J6C3Rk234aK4enfoirPnifeoJ7n0Eti+69CLl/Y0ZU5wqesQY6LkonJl8Cgt+j1y1eA3Ld3ilb8//9CA==",
+			"version": "2.98.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.98.0.tgz",
+			"integrity": "sha512-+hEuVxoJ6qANCbvZzwZUuivpSKBvPtAEUi1t/yzgo4DktnTMNmYTHBYHRoyE1U+3ysCjrCnhUZSwolX2kjzZEQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1430,9 +1431,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/win32-arm64-msvc": {
-			"version": "2.91.0",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-2.91.0.tgz",
-			"integrity": "sha512-8FHsFrD1np1Fq1+jI+c3aTtlkGwMqPsfPUqfjeXopQGBDGM+XQX970/3WaPoCVx7pGAHQrMvYDRt7rSra+knvw==",
+			"version": "2.98.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-2.98.0.tgz",
+			"integrity": "sha512-90zE6+aMKBQHLTgQ5oDXd1as26OjapokGJpX3yc+q4rLfofgSFogVffNbrLRlYTkWtEMBRub98NLEajlZoI3CQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1444,9 +1445,9 @@
 			]
 		},
 		"node_modules/@fallow-cli/win32-x64-msvc": {
-			"version": "2.91.0",
-			"resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.91.0.tgz",
-			"integrity": "sha512-0ebx+vkEuTit3MIy/3b1xezsyp+xz67fR49Mq6tBqlPAXRXgVYc9rAsSSzHpqFFIU9U8cpqbSKFpJskRscluCg==",
+			"version": "2.98.0",
+			"resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.98.0.tgz",
+			"integrity": "sha512-ibmYWggQvkeKSvdzBu6d3XcmgxgggbHugYfwECsWSlHfBmkBOktx38eU/72VpEzSEsJfbGM7q77so/284VD8tw==",
 			"cpu": [
 				"x64"
 			],
@@ -1978,9 +1979,9 @@
 			}
 		},
 		"node_modules/@lucide/svelte": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.17.0.tgz",
-			"integrity": "sha512-q06YCFBN5CO8cd1ADmLCxWRVMVb7xxvHzqC0lvNoxGa+FLW6Cd1Y1AOxgbQk4Iwe68vkAMCRveNHint4WoaVKg==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.20.0.tgz",
+			"integrity": "sha512-s7TKCHEtFEfflOUDPRC0WBZEjoNJHtj/aUmuWxopFe3AKecEoKvMmCaO0sBDkflok8nR0BCFsm44QF+S6/gc+w==",
 			"dev": true,
 			"license": "ISC",
 			"peerDependencies": {
@@ -2051,9 +2052,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-			"integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+			"integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2083,12 +2084,12 @@
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
-			"integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+			"integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.7.1",
+				"@opentelemetry/core": "2.8.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -2099,13 +2100,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
-			"integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+			"integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "2.7.1",
-				"@opentelemetry/resources": "2.7.1",
+				"@opentelemetry/core": "2.8.0",
+				"@opentelemetry/resources": "2.8.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
@@ -2125,9 +2126,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-android-arm-eabi": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.133.0.tgz",
-			"integrity": "sha512-l/44caGse+VpnY9gx0yvvc5QnnG3yG1FO3KZgYvNL1GZrfK86zIwAOgGEVlxDyRymzrU/KHiblPFpevKOmJmUA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.135.0.tgz",
+			"integrity": "sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ==",
 			"cpu": [
 				"arm"
 			],
@@ -2142,9 +2143,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-android-arm64": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.133.0.tgz",
-			"integrity": "sha512-KUHmPMziLBp4u+zbrLdB7iWS7KshuZe+RAp7ELnY9SI9nNXBZ+dp8fiBqWOxhXqn+FQg3a4UcQhwmsJOKV8Jjg==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.135.0.tgz",
+			"integrity": "sha512-wPte+SzgzWWFgMSF8YZDNM+tBXtJg0AXBi7+tU3yS2z1f2Af9kRLZLKuJojADmuD/cZexmnMHHC3SDItTW77Iw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2159,9 +2160,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-darwin-arm64": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.133.0.tgz",
-			"integrity": "sha512-q8dWmnU/8ea2tga9w2f1PinQ5rcMPDUGkF64T189b65YMjUomET4oy5oRldOr4AwOQkneOG/Zttnz1Dvrc62wg==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.135.0.tgz",
+			"integrity": "sha512-BmKz3lHIsqVos+9aPcdYCT9MG3APoUyM43KlEFhJMWNVDOGG8FKyiFz81Bc+mGz2o0hpuQ3PfXLfVWJrKXjo2g==",
 			"cpu": [
 				"arm64"
 			],
@@ -2176,9 +2177,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-darwin-x64": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.133.0.tgz",
-			"integrity": "sha512-cOKeIELIB2bJnCKwqx4Rdj+1Lss/U6uCbLxRySZrhyOOQa1flKhwZFjEHRHxk8fU1NKmhK5OnTdPQ4CpjuFuVw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.135.0.tgz",
+			"integrity": "sha512-dM8BS+8+Br1fNvmh2QZbGiHaYttwLebRa6J4Uz9vuFzMNmvsdRYwf7993ptOaV0JTrR63AaoVLjX7nhWbijxjQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2193,9 +2194,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-freebsd-x64": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.133.0.tgz",
-			"integrity": "sha512-OpaSv4pW3KgFrMYQxTaS0aOE4T1DQF3qZE/4B6uqqv1KgPWWd4UQhJALi8PJPX1RRV5K7ThKXRfF7qGg2+3l1A==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.135.0.tgz",
+			"integrity": "sha512-xlZnvvJdR9bGu2pOhvR5hMuKPHCE6Sa9owK5A484mzjHdm75VRV5nCs5w/jkmGODMMTFc+KN7EnZqEieM813kw==",
 			"cpu": [
 				"x64"
 			],
@@ -2210,9 +2211,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.133.0.tgz",
-			"integrity": "sha512-JGK1wlGrGwxBIlVSF7KWTX1/ru6BEtf28fRROztDRkLfiW+Kxa4onnriezMIiogfn9hVw2KzYcKiLjkLR2ns8A==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.135.0.tgz",
+			"integrity": "sha512-PSR8LmBK/H/PQRiN8g7RebQgZX/ntVCrdT/JBfNxE5ezdHG1s2i4rbazsRJYD83TTI1MmgTpC0MGL42PLtskQQ==",
 			"cpu": [
 				"arm"
 			],
@@ -2227,9 +2228,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.133.0.tgz",
-			"integrity": "sha512-yuZO533Ftonxn/iyoqQzURzLQHMspvsIyfiCSNi1t/ER4eIQaR0SsmUOUm5b/lmSig7IWIUa5/BrbEkAPwcilQ==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.135.0.tgz",
+			"integrity": "sha512-I85GJXzfUsigkkk7Ngdz95C217M4FdUi1Z2HrX5UyPmURobwQZ7m2bbUvwFkz4VGZd+lymFGKHvDZ3RQC9qOzA==",
 			"cpu": [
 				"arm"
 			],
@@ -2244,9 +2245,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.133.0.tgz",
-			"integrity": "sha512-hvpbqT5pN2rR+3+xtWeizwfR/aZ0vGceg6TqYMl+ToxMpk9/tmnX7kSvQnfEUkoua8mhogzvIKsAkn0wxgblBA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.135.0.tgz",
+			"integrity": "sha512-zqEY0npz0g0aGZj/8a5BclunjVDytsBQHYtIC10Gd26HcrLwbVF6YDbqRQjunMGYdSo97u6xOBl05aTDI2diDQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2264,9 +2265,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm64-musl": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.133.0.tgz",
-			"integrity": "sha512-wJQGamIosQBoJHW9+S5XxrtKRo3eyJxsnS1XCPrqN0LHi8uw1pTqqTfn3t/NVuvbBg7Pumn4ez9Eidgcn0xbEg==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.135.0.tgz",
+			"integrity": "sha512-mWAfprP819gQ2qYst1RxgTI8b/z0b29OpoKfRflIXLHde2dZLihQD4g47Onuvtpo5GPIkMYPRlX9QoeZfs/GnQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2284,9 +2285,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.133.0.tgz",
-			"integrity": "sha512-Koaz32/O5+abIfrNGdyndgRvdOZ9jEf5/z3Ep9h3h2QWpdDiUQpVwgH0OcMXCs+l9aXxPLtkupqyVig9W6FDKw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.135.0.tgz",
+			"integrity": "sha512-gri8c2AOmJKJwOux2KTHFBfUaXoJURuVMKhmKEi/2hTF55cQteTDV2XNfTiE5oCC+Tnem1Y4/MWzcyDadtsSag==",
 			"cpu": [
 				"ppc64"
 			],
@@ -2304,9 +2305,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.133.0.tgz",
-			"integrity": "sha512-R4vOjWzxhnNWHnVLeiB6jNuIifdy9vcMXZGPc7StXcxBovI+U2zg1QhZ9o8OjV80oGivs1lX5NfPLzk4IPqlRA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.135.0.tgz",
+			"integrity": "sha512-Y2tkupCG5wo0SxH2rMLG4d4Kmv6DaM3sBp+GuM5lox0S8Za6VxKgQrY2Mut088QQxKkEE89n/4CCCgmw2o0e3Q==",
 			"cpu": [
 				"riscv64"
 			],
@@ -2324,9 +2325,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.133.0.tgz",
-			"integrity": "sha512-iwgBNUTHiMdxARLYuM0SBlnYeb19iw1Ea5M+4ERZupCsBMLArti6FyZ6UfFjJxIiTDr2oW2DGQFxlQVQ/dW9rA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.135.0.tgz",
+			"integrity": "sha512-xDRJq6i6WTynjeP+ISbDpyH4p9BaJ0wuQcL0lCSDkt9qOXC9dmwpOu1VG/TlwmPI3KpYntmO9nJCuc3TMTsNBA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -2344,9 +2345,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.133.0.tgz",
-			"integrity": "sha512-ZwZNo8FZmB/gVfboQl+wXilBigGl+6nQQs+nITOeAP/HcAOjiHl6XZJL9F/KXNEspODQcbjAiyjUbeCJd9a0fA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.135.0.tgz",
+			"integrity": "sha512-V4MoUuiCRNvihxhIufRxvK+ka013V4joTSK0FAGA1KEjLuNprfH6N/Qw2uxQEVIFuNYMhD/hV6xJ/ptbzlKdHg==",
 			"cpu": [
 				"s390x"
 			],
@@ -2364,9 +2365,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-x64-gnu": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.133.0.tgz",
-			"integrity": "sha512-govCvWx1dBlED3uu4qXctxpRcouu9I8Kn+DBktGCl760JtlGJzc9l/OmPJKlYWSbrRqKkMZehNeZ/4Wfma7uSA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.135.0.tgz",
+			"integrity": "sha512-JCFZ7zM7KXOKoPAbK/ZB4wY0M1jxRECiem2UQuiXLjzGqS9+hno7mtX+qyK2F7HWK2xPhyJb+frpcOtk5DKOtg==",
 			"cpu": [
 				"x64"
 			],
@@ -2384,9 +2385,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-x64-musl": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.133.0.tgz",
-			"integrity": "sha512-ssTlpXD5Mq9uCssDJPzlRWqBt4Y7Zzd9i+XZhWmK/9Y6KUIuAxVYTYiI8lxcGWi0+3/Cz4A8q9UrD4NK9Y2j7g==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.135.0.tgz",
+			"integrity": "sha512-9jSVS1b3hOV7sdKH4aA2DFfnTz0RgQd0v2BefR+LYbH8yIlmSM22JJZbAAjVeVXmFgUAk3zJQ1tpE/Nd+Vi2YQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2404,9 +2405,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-openharmony-arm64": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.133.0.tgz",
-			"integrity": "sha512-51aByfXhPtLEdWG4a2Ihdw6cPWV1ei1AarALpFdDP8MLWDLE2NuUMgbo3DERR2Kt8fT/ok1GUvBiLxVGke9uUQ==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.135.0.tgz",
+			"integrity": "sha512-M857ZLBSdn1Uy/SJJz5zh0qGu67B4P9omCgXGBU2LLqTzraX6ZjVNaKq5yW1PDw/LgJXDXR/dbZfgmB310f11Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -2421,9 +2422,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-wasm32-wasi": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.133.0.tgz",
-			"integrity": "sha512-2e16tkKp+wDO2GTAmXfxbBcCmGEaFPIJEIRBBmVKNVXSc8/fJsSIaBGyFTPHM9ST5GNWgJcYIt94rDTks+PLwA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.135.0.tgz",
+			"integrity": "sha512-2w6DVcntQZX9U5RhXtgiWb3FLWFB5EcwI1U8yr3htOCJUJjagN4BFUHz/Y/d9ZsumndZ6ByxxWEtbUZNE1bfFw==",
 			"cpu": [
 				"wasm32"
 			],
@@ -2440,9 +2441,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.133.0.tgz",
-			"integrity": "sha512-KPTNDKbxH1cglrqTyVeXHb4Pk4oksz8EcE1/v8zqU7N4UXbiHfA/IwtXZ2U77fnRAWBbgVkl/lZbL7o3hRdejg==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.135.0.tgz",
+			"integrity": "sha512-rX1U8+IH2Z37EJjDXKa1iifvUQAdba+vZ4Ewj1iaG5eA/QaSybzclCOwtWa0/5BuUQnnK/T2JHUEFrwhL6Ck2Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -2457,9 +2458,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.133.0.tgz",
-			"integrity": "sha512-Una1bNYv9zCavQrfnDR9wuZVB3itLjCEH4Oz7i6CwAJN/Xq9b+zbbcxmvdkKvvJt4Ngc/MBmIYlbLo3zS4TQ0A==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.135.0.tgz",
+			"integrity": "sha512-9FAisBbH1QICGAjlJobiuKGd/jOuVmyqniWdQMwTa5SkCl6hhuotBCJf1n46B0flYbSOR5TzfV9HZCWSyb3c/Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -2474,9 +2475,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-win32-x64-msvc": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.133.0.tgz",
-			"integrity": "sha512-kjBhCiOGSYTwDJQuuZa7a94JbP8htWu7J0X1KwH74kV2K5eYf6eyJRYmkpCDvr0XEL8tMxYI4WU1VekblFCLgg==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.135.0.tgz",
+			"integrity": "sha512-wYF+A2AzJ2n7ul6q+Z2G/ia0S2+8cUp0AgWZzoFvF4WmUcl1P7p+o6se1Gdr5wGnWuF0iAMIkGddrjCarNr2yA==",
 			"cpu": [
 				"x64"
 			],
@@ -2491,18 +2492,19 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-			"integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.135.0.tgz",
+			"integrity": "sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
 		"node_modules/@oxc-resolver/binding-android-arm-eabi": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.20.0.tgz",
-			"integrity": "sha512-IjfWOXRgJFNdORDl+Uf1aibNgZY2guOD3zmOhx1BGVb/MIiqlFTdmjpQNplSN58lhWehnX4UNqC3QwpUo8pjJg==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.21.2.tgz",
+			"integrity": "sha512-xQoCRv+gKax9KTdwdaQNnAFOai8neay7g3jExDIORzhbrejwGSJaZNTdOJHR5ziLg2joMxOCMOFMo4zuxza2uQ==",
 			"cpu": [
 				"arm"
 			],
@@ -2514,9 +2516,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-android-arm64": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.20.0.tgz",
-			"integrity": "sha512-QqslZAuFQG8Q9xm7JuIn8JUbvywhSBMVhuQHtYW+auirZJloS41oxUUaBXk7uUhZJgp44c5zQLeVvmFaDQB+2Q==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.21.2.tgz",
+			"integrity": "sha512-HF5oiE2L05yInPYCFD/4uxSrEZW4SuIfn99Y6L1xnJnzl066JR+MJs2rIdstw8A2MPlAKH+13dpFPNycjqzvGg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2528,9 +2530,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-darwin-arm64": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.20.0.tgz",
-			"integrity": "sha512-MUcavykj2ewlR+kc5arpg4tC2RvzJkUxWtNv74pf7lcNk00GpIpN43vXMj+j6r4eMmfZhlb8hueKoIb8e9kAGQ==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.21.2.tgz",
+			"integrity": "sha512-UX4u49CVCAD8QZNELaW8eMGgMAGwFWYEPbvNsh+3r/gs4NX3KfpiACMVwRQT0EuH3uat9hM5Zl+Ppm9pJD8tgg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2542,9 +2544,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-darwin-x64": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.20.0.tgz",
-			"integrity": "sha512-BGB16nRUK5Etiv//ihPyzj8Lj1px0mhh4YIfe0FDf045ywknfSm0GEbiRESpr6Q4K82AvnyaRIhhluHByvS4bg==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.21.2.tgz",
+			"integrity": "sha512-J9xPx7YBkrRmJ+xl561ztnMWEc1aOyjEIxBiGX1dVb3u7bGSnfObfcZk+Pd+uM0HZAPNsQ1xvD8j52A/uOSqNQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2556,9 +2558,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-freebsd-x64": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.20.0.tgz",
-			"integrity": "sha512-JZgtePaqj3qmD5XFHJaSLWzHRxQu0LaPkdoM1KJXYADvAaa83ijXHclV3ej3CueeW0wxfIAbGCZVP45J0CA7uQ==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.21.2.tgz",
+			"integrity": "sha512-fRlt7OvSaQkWj6+EDTVxawVxOlqJB2QSnBfkeCyK4RTvsGctbw3BiH2Tb7DzMs7bikc4BRBpvWP5zF9K8b54Zg==",
 			"cpu": [
 				"x64"
 			],
@@ -2570,9 +2572,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.20.0.tgz",
-			"integrity": "sha512-hOQ/p3ry3v3SchUBXicrrnszaI/UmYzM4wtS4RGfwgVUX7a+HbyQSzJ5aOzu+o6XZkFkS3ZXN4PZAzhOb77OSg==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.21.2.tgz",
+			"integrity": "sha512-gK+vPUcPQITkGwBKpZGrcDHSlU6eDGl7AQacxS2CEKAZIBHWkOVFeJwLZ4tYnA1acJqRM5lt7yYwPCVqGHIJ7A==",
 			"cpu": [
 				"arm"
 			],
@@ -2584,9 +2586,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.20.0.tgz",
-			"integrity": "sha512-2ArPksaw0AqeuGBfoS715VF+JvJQAhD2niWgjE5hVO+L+nAfikVQopvngCMX9x4BD8itWoQ3dnikrQyl5Ho5Jg==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.21.2.tgz",
+			"integrity": "sha512-L/Rgas7SrOKy/z7IH+HxSFRqVO4PuLDKLEGKvnhoCBBq3UJ0YzGBou3qMzaAGgkJwsIvX2pBF+7ojzfUhLiZxQ==",
 			"cpu": [
 				"arm"
 			],
@@ -2598,9 +2600,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.20.0.tgz",
-			"integrity": "sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.21.2.tgz",
+			"integrity": "sha512-CUEYvlX1Fk7E9kUMzuswru1J9HLxMwnpDeQGjQuI4ZH+iNCoa2X9T+pvyzrbsgl7WnIeTFTlNlHsRfVdf5g9/g==",
 			"cpu": [
 				"arm64"
 			],
@@ -2615,9 +2617,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-linux-arm64-musl": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.20.0.tgz",
-			"integrity": "sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.21.2.tgz",
+			"integrity": "sha512-ViN1ZibQyxwC67GpoP33oo+S9UyUnkog13vzQb9+v9bCNvrVzJuk0MRdacjtv/9xfRMVF/eqHFyl8YOeykI10Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -2632,9 +2634,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.20.0.tgz",
-			"integrity": "sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.21.2.tgz",
+			"integrity": "sha512-CU1sCqWnhGqYD5I1HedHk5pujrn7ssDkNB/AEQd/pd3D/EojVSgJUlpbafwIbyhia3PgIfkvdFpRPWSALzVumA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -2649,9 +2651,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.20.0.tgz",
-			"integrity": "sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.21.2.tgz",
+			"integrity": "sha512-jWVyZtIHca4Gb96x7dag+y69vlei7ffjrsveLkmf2ZhqEAz6ZSBnY1GWvgZUaZlwZP62A3xD092BW97Q5VGc+g==",
 			"cpu": [
 				"riscv64"
 			],
@@ -2666,9 +2668,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.20.0.tgz",
-			"integrity": "sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.21.2.tgz",
+			"integrity": "sha512-LF29obFqNgBUgDX7rmUK7M4D0JQG5LxhYzn3xXmECcHU9aQAdWG7NiY052qybtesEdwHQXKNTWYQ7mTsybNvWg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -2683,9 +2685,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.20.0.tgz",
-			"integrity": "sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.21.2.tgz",
+			"integrity": "sha512-+NYcm+cCHBbtdQQ3A4phQTSuVRYnNHz7wrl9XRAPEovcdoqi0mb1K5ZOl+jN54ZD+q1zz3V0vltbFJmzecJKmw==",
 			"cpu": [
 				"s390x"
 			],
@@ -2700,9 +2702,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-linux-x64-gnu": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.20.0.tgz",
-			"integrity": "sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.21.2.tgz",
+			"integrity": "sha512-UQqZDdG2r2HhAOsZEgufkIWHPQ886IUyuJQkoZByvzhW8j51R4UNzGBJFkTiTnLhQnggwJRdJgFWK4uY6ZVIMw==",
 			"cpu": [
 				"x64"
 			],
@@ -2717,9 +2719,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-linux-x64-musl": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.20.0.tgz",
-			"integrity": "sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.21.2.tgz",
+			"integrity": "sha512-3Q9PMRjalWkT6NZ4jfujuqTCFwoWErg3y3BnOgb544B8IMw4PktiwWOigMfOHNRLMghZeJ7hpfpZf4CP7rV7Og==",
 			"cpu": [
 				"x64"
 			],
@@ -2734,9 +2736,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-openharmony-arm64": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.20.0.tgz",
-			"integrity": "sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.21.2.tgz",
+			"integrity": "sha512-Eljeq3ndtyKhM+Es8LITi4Zl2htzuRZcrPMF3kMCsrILztvU6AjZ3FuEhHHKobPUB9rMpzLpJP5bDqXI7r+iog==",
 			"cpu": [
 				"arm64"
 			],
@@ -2748,9 +2750,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-wasm32-wasi": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.20.0.tgz",
-			"integrity": "sha512-Tn0y1XOFYHNfK1wp1Z5QK8Rcld/bsOwRISQXfqAZ5IBpv8Gz1IvV39fUWNprqNdRizgcvFhOzWwFun2zkJsyBg==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.21.2.tgz",
+			"integrity": "sha512-HGDbNsIywqc4LxU38+CTJNnB/6BF7rheWOJ259b4eE0aEnelYblC8x+1tEd63bp31fYne63RQz9Jb4yVnC7Yig==",
 			"cpu": [
 				"wasm32"
 			],
@@ -2758,18 +2760,52 @@
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/core": "1.10.0",
-				"@emnapi/runtime": "1.10.0",
-				"@napi-rs/wasm-runtime": "^1.1.4"
+				"@emnapi/core": "1.11.0",
+				"@emnapi/runtime": "1.11.0",
+				"@napi-rs/wasm-runtime": "^1.1.5"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+			"integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+			"integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.20.0.tgz",
-			"integrity": "sha512-qPi25YNPe4YenS8MgsQU2+bIFHxxpLx1LVna2444cEHqNPhNjvWf9zqj4aWE43H9LpAsTmkkAlA3eL5ElBU3mA==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.21.2.tgz",
+			"integrity": "sha512-iWx25CBEgH49iE9q5coEGI/jb1jl5kkCY9z6U5Og67xCkQ/WFMDc2J5U78+AE91SUxM2NqSLhJC8/PLfWnImww==",
 			"cpu": [
 				"arm64"
 			],
@@ -2781,9 +2817,9 @@
 			]
 		},
 		"node_modules/@oxc-resolver/binding-win32-x64-msvc": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.20.0.tgz",
-			"integrity": "sha512-Wb14jWEW8huH6It9F6sXd9vrYmIS7pMrgkU6sxpLxkP+9z+wRgs71hUEhRpcn8FOXAFa27FVWfY2tRpbfTzfLw==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.21.2.tgz",
+			"integrity": "sha512-VPoCAhKvCQTlG7vxqaBXcmuvbh77BfnGXj8g0pbvVXpm1F/R8rDVwqIWcEbMzrI1JvJlm8v7T9uMVQb6UctMRg==",
 			"cpu": [
 				"x64"
 			],
@@ -3226,9 +3262,9 @@
 			]
 		},
 		"node_modules/@oxlint/binding-android-arm-eabi": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.69.0.tgz",
-			"integrity": "sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.70.0.tgz",
+			"integrity": "sha512-zFh0P4cswmRvw6nkyb89dr18rRanuaCPAsEXsFDoQY8WdaquI8Pt4NWFjaMJg6L23cy5NeN8J9cBnREbWzZhaw==",
 			"cpu": [
 				"arm"
 			],
@@ -3243,9 +3279,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-android-arm64": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.69.0.tgz",
-			"integrity": "sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.70.0.tgz",
+			"integrity": "sha512-qI8o4HZjeGiBrWv+pJv4lH0Yi2Gl/JSp/EumBUApezJprIKa5PS4nU0lQsQngtky8k+SplQIOjv6hwu0SSxeyg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3260,9 +3296,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-darwin-arm64": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.69.0.tgz",
-			"integrity": "sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.70.0.tgz",
+			"integrity": "sha512-8KjgVVHI5F9nVwHCRwwA78Ty7zNKP4Wd9OeN5PSv3iu/F/u1RVXoOCgLhWqust6HmwQG6xc8c+RCyaWENy24+w==",
 			"cpu": [
 				"arm64"
 			],
@@ -3277,9 +3313,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-darwin-x64": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.69.0.tgz",
-			"integrity": "sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.70.0.tgz",
+			"integrity": "sha512-WVydssv5PSUBXFJTdNBWlmGkbNmvPGaFt/2SUT/EZRB6bq6bEOHmMlbnupZD5jmlEvi9+mZJHi8TCw15lyfSfQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3294,9 +3330,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-freebsd-x64": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.69.0.tgz",
-			"integrity": "sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.70.0.tgz",
+			"integrity": "sha512-hJucmUf8OlinHNb1R7fI4Fw6WsAstOz7i8nmkWQfiHoZXtbufNm+MxiDTIMk1ggh2Ro4vLzgQ+bKvRY54MZoRA==",
 			"cpu": [
 				"x64"
 			],
@@ -3311,9 +3347,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.69.0.tgz",
-			"integrity": "sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.70.0.tgz",
+			"integrity": "sha512-1BnS7wbCYDSXwWzJJ+mc3NURoha6m6m6RT5c6vgAY3oz7C3OVXP+S0awo2mRq97arrJkVvO3qRQfyAHL+76xtQ==",
 			"cpu": [
 				"arm"
 			],
@@ -3328,9 +3364,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm-musleabihf": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.69.0.tgz",
-			"integrity": "sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.70.0.tgz",
+			"integrity": "sha512-yKy/UdbR55+M2yEcuiV5DCNC/gdQAjr/GioUy50QwBzSrKm8ueWADqyRLS9Xk+qjNeCYGg6A8FvUBds56ttfqg==",
 			"cpu": [
 				"arm"
 			],
@@ -3345,9 +3381,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm64-gnu": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.69.0.tgz",
-			"integrity": "sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.70.0.tgz",
+			"integrity": "sha512-0A5XJ4alvmqFUFP/4oYSyaO+qLto/HrKEWTSaegiVl+HOufFngK2BjYw9x4RbwBt/du5QG6l5q1zeWiJYYG5yg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3365,9 +3401,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-arm64-musl": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.69.0.tgz",
-			"integrity": "sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.70.0.tgz",
+			"integrity": "sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A==",
 			"cpu": [
 				"arm64"
 			],
@@ -3385,9 +3421,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-ppc64-gnu": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.69.0.tgz",
-			"integrity": "sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.70.0.tgz",
+			"integrity": "sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q==",
 			"cpu": [
 				"ppc64"
 			],
@@ -3405,9 +3441,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-riscv64-gnu": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.69.0.tgz",
-			"integrity": "sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.70.0.tgz",
+			"integrity": "sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -3425,9 +3461,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-riscv64-musl": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.69.0.tgz",
-			"integrity": "sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.70.0.tgz",
+			"integrity": "sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g==",
 			"cpu": [
 				"riscv64"
 			],
@@ -3445,9 +3481,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-s390x-gnu": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.69.0.tgz",
-			"integrity": "sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.70.0.tgz",
+			"integrity": "sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA==",
 			"cpu": [
 				"s390x"
 			],
@@ -3465,9 +3501,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-x64-gnu": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.69.0.tgz",
-			"integrity": "sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.70.0.tgz",
+			"integrity": "sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3485,9 +3521,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-linux-x64-musl": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.69.0.tgz",
-			"integrity": "sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.70.0.tgz",
+			"integrity": "sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg==",
 			"cpu": [
 				"x64"
 			],
@@ -3505,9 +3541,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-openharmony-arm64": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.69.0.tgz",
-			"integrity": "sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.70.0.tgz",
+			"integrity": "sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A==",
 			"cpu": [
 				"arm64"
 			],
@@ -3522,9 +3558,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-win32-arm64-msvc": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.69.0.tgz",
-			"integrity": "sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.70.0.tgz",
+			"integrity": "sha512-icAEsUI7JbW1TMRdEXV83mVAInhRVQYuuAlPpxdGwJ95chNdnCzjloRW8GglT0WvzOEZSio6fnYSk2DJ2Hv7LQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3539,9 +3575,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-win32-ia32-msvc": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.69.0.tgz",
-			"integrity": "sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.70.0.tgz",
+			"integrity": "sha512-FHMSWbVsPVs/f+Jcl04ws4JJ2wUnauyTzlpxWRG/lSO/8GpX08Fo2gQZqdA6CrRFI+zvkxl+N/KwJGWfUwYVZA==",
 			"cpu": [
 				"ia32"
 			],
@@ -3556,9 +3592,9 @@
 			}
 		},
 		"node_modules/@oxlint/binding-win32-x64-msvc": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.69.0.tgz",
-			"integrity": "sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.70.0.tgz",
+			"integrity": "sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g==",
 			"cpu": [
 				"x64"
 			],
@@ -3949,9 +3985,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
-			"integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+			"integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
 			"cpu": [
 				"arm"
 			],
@@ -3962,9 +3998,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
-			"integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+			"integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3975,9 +4011,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
-			"integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+			"integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3988,9 +4024,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
-			"integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+			"integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
 			"cpu": [
 				"x64"
 			],
@@ -4001,9 +4037,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
-			"integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+			"integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -4014,9 +4050,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
-			"integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+			"integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
 			"cpu": [
 				"x64"
 			],
@@ -4027,9 +4063,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
-			"integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+			"integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
 			"cpu": [
 				"arm"
 			],
@@ -4043,9 +4079,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
-			"integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+			"integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
 			"cpu": [
 				"arm"
 			],
@@ -4059,9 +4095,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
-			"integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+			"integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -4075,9 +4111,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
-			"integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+			"integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
 			"cpu": [
 				"arm64"
 			],
@@ -4091,9 +4127,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
-			"integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+			"integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
 			"cpu": [
 				"loong64"
 			],
@@ -4107,9 +4143,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
-			"integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+			"integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
 			"cpu": [
 				"loong64"
 			],
@@ -4123,9 +4159,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
-			"integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+			"integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
 			"cpu": [
 				"ppc64"
 			],
@@ -4139,9 +4175,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
-			"integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+			"integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -4155,9 +4191,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
-			"integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+			"integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -4171,9 +4207,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
-			"integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+			"integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -4187,9 +4223,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
-			"integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+			"integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
 			"cpu": [
 				"s390x"
 			],
@@ -4203,9 +4239,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
-			"integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+			"integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
 			"cpu": [
 				"x64"
 			],
@@ -4219,9 +4255,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
-			"integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+			"integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
 			"cpu": [
 				"x64"
 			],
@@ -4235,9 +4271,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
-			"integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+			"integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
 			"cpu": [
 				"x64"
 			],
@@ -4248,9 +4284,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
-			"integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+			"integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
 			"cpu": [
 				"arm64"
 			],
@@ -4261,9 +4297,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
-			"integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+			"integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
 			"cpu": [
 				"arm64"
 			],
@@ -4274,9 +4310,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
-			"integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+			"integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
 			"cpu": [
 				"ia32"
 			],
@@ -4287,9 +4323,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
-			"integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+			"integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
 			"cpu": [
 				"x64"
 			],
@@ -4300,9 +4336,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
-			"integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+			"integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
 			"cpu": [
 				"x64"
 			],
@@ -4311,68 +4347,6 @@
 			"os": [
 				"win32"
 			]
-		},
-		"node_modules/@sentry-internal/browser-utils": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.57.0.tgz",
-			"integrity": "sha512-tXObp954rMTSYKlbftjVXHtNl4t/6ssks3jkqyzmKb+PDPWzabGQO7sWwqVuTjT8Kx/8A3FmriS1bGmqxiJy3A==",
-			"license": "MIT",
-			"dependencies": {
-				"@sentry/core": "10.57.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@sentry-internal/feedback": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.57.0.tgz",
-			"integrity": "sha512-ZcF4QhkqGX3iiQSXB2N0N3Awp+j5iqnDRu6PA/qyLFrWqH5ZiiAAgu59OLD9E6XAdg6iFtLYw19MAMZVK8qNOQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@sentry/core": "10.57.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@sentry-internal/replay": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.57.0.tgz",
-			"integrity": "sha512-Wmnx/6ABynVH1iwuoNUqJNyjIUqsqoGML7qsyivBRKb5Wo2YQtPOQlQYfxfZSvWzGpcoSVdInkRjDssUQxQEQg==",
-			"license": "MIT",
-			"dependencies": {
-				"@sentry-internal/browser-utils": "10.57.0",
-				"@sentry/core": "10.57.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@sentry-internal/replay-canvas": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.57.0.tgz",
-			"integrity": "sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A==",
-			"license": "MIT",
-			"dependencies": {
-				"@sentry-internal/replay": "10.57.0",
-				"@sentry/core": "10.57.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@sentry-internal/server-utils": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/server-utils/-/server-utils-10.57.0.tgz",
-			"integrity": "sha512-Qu8ETmX/ITzteG7Im46b9HOxKKzeaIeqNvftaIlFURu1RUQdHbtGerS7QOmXzwnhuqNGNeiCQYkduB798IfRqA==",
-			"license": "MIT",
-			"dependencies": {
-				"@sentry/core": "10.57.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
 		},
 		"node_modules/@sentry/babel-plugin-component-annotate": {
 			"version": "5.3.0",
@@ -4384,16 +4358,28 @@
 			}
 		},
 		"node_modules/@sentry/browser": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.57.0.tgz",
-			"integrity": "sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA==",
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.58.0.tgz",
+			"integrity": "sha512-Syf6h6HDwC15fk86+/0ql8ebwwJFw2wp+lvOX9GfLTJVOqrSILCrtLKNI+f4v/3w8mzImsv9ttJGGbUugLNvcA==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry-internal/browser-utils": "10.57.0",
-				"@sentry-internal/feedback": "10.57.0",
-				"@sentry-internal/replay": "10.57.0",
-				"@sentry-internal/replay-canvas": "10.57.0",
-				"@sentry/core": "10.57.0"
+				"@sentry/browser-utils": "10.58.0",
+				"@sentry/core": "10.58.0",
+				"@sentry/feedback": "10.58.0",
+				"@sentry/replay": "10.58.0",
+				"@sentry/replay-canvas": "10.58.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/browser-utils": {
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.58.0.tgz",
+			"integrity": "sha512-TzXrhZq3Llj6qPSv0ZVG5N5c7C6qNN/aRKJXhq2LombJrLwiQrWdgizp7zdHA0FGlZ7F5YpyRA2JIpkhvrFqYA==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/core": "10.58.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -4583,13 +4569,13 @@
 			}
 		},
 		"node_modules/@sentry/cloudflare": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.57.0.tgz",
-			"integrity": "sha512-LDKk177la/uG92ILNozcwQR7+4/pizPu01Y7M7l9J7o1uwAi9WjElafh/HU2Jqw+vST1BKknw/tQB1pnsnkDlA==",
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.58.0.tgz",
+			"integrity": "sha512-84Zk8Ala/+JoJ+/POnjQ7Udn64GO7kIlcas9c5Kgld5hUBicPSIoePshI3NkQeZwcHRbRioNaU8PwnV5yBBoSw==",
 			"license": "MIT",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.1",
-				"@sentry/core": "10.57.0"
+				"@sentry/core": "10.58.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -4604,18 +4590,30 @@
 			}
 		},
 		"node_modules/@sentry/core": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.57.0.tgz",
-			"integrity": "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==",
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.58.0.tgz",
+			"integrity": "sha512-bkIbh2c6dzwhrWn/FGWu7j8hf6TAat2XxpkGM91LiN09fLYUXIMwcohVsXqze5l2cq35TnvqmSROAbRNr27GVw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
 		},
+		"node_modules/@sentry/feedback": {
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.58.0.tgz",
+			"integrity": "sha512-VmIlR/0O0GXITbvgjPkQqd6yM0JDEk52WXv6Rs1kTdaIDU5h3Y64VDVN4MAbYVRHqSz7F1arjRRk2FkaKC7ZOQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/core": "10.58.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@sentry/node": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.57.0.tgz",
-			"integrity": "sha512-7KEStrJ97wPf1fA5nU5ONeTTcIIlh7oT8OMffEVA1PXmlhFoXhcQZVzr4rM+zj9tfMWT01og5Ng/Grgh3dN+FA==",
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.58.0.tgz",
+			"integrity": "sha512-KICgacBS+I/eWzFlAembutSwFwy0WVSrGp8UMV9n1XZqqu4EBTlALRsbLNlDSv61UgH85L9L3vk91tgq6nJXAA==",
 			"license": "MIT",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.1",
@@ -4623,10 +4621,10 @@
 				"@opentelemetry/instrumentation": "^0.214.0",
 				"@opentelemetry/sdk-trace-base": "^2.6.1",
 				"@opentelemetry/semantic-conventions": "^1.40.0",
-				"@sentry-internal/server-utils": "10.57.0",
-				"@sentry/core": "10.57.0",
-				"@sentry/node-core": "10.57.0",
-				"@sentry/opentelemetry": "10.57.0",
+				"@sentry/core": "10.58.0",
+				"@sentry/node-core": "10.58.0",
+				"@sentry/opentelemetry": "10.58.0",
+				"@sentry/server-utils": "10.58.0",
 				"import-in-the-middle": "^3.0.0"
 			},
 			"engines": {
@@ -4634,13 +4632,13 @@
 			}
 		},
 		"node_modules/@sentry/node-core": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.57.0.tgz",
-			"integrity": "sha512-2v2IF6MfTiu7pimWEq2rYhZsmlwyNbs3bHUsrYFPeP/Rpa6ObDuUWPdVEzJjfyK+AqqYZYxZdV0l3+B13kTEmQ==",
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.58.0.tgz",
+			"integrity": "sha512-7dTbYuoaSwSmF2GWDl7KK+sXQL8iqaZeZ2I/aFm+SvPZLckZF3OGFb2VsluWsSXQLnxtxPX9QP93viyK+VZsuA==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "10.57.0",
-				"@sentry/opentelemetry": "10.57.0",
+				"@sentry/core": "10.58.0",
+				"@sentry/opentelemetry": "10.58.0",
 				"import-in-the-middle": "^3.0.0"
 			},
 			"engines": {
@@ -4676,12 +4674,12 @@
 			}
 		},
 		"node_modules/@sentry/opentelemetry": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.57.0.tgz",
-			"integrity": "sha512-iwRz8cEK0GOISG34aJRO8GdYOk3nfpuT6dT2GDQrxw8f7JjkJKx9LPU8MaenOFa4MhY+Z02hI6NNcrbsoI3cXg==",
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.58.0.tgz",
+			"integrity": "sha512-qKOGVmt02wDaq7E70VekG8Z9XM641trJPoTHSeVUfGaXVcmGc46ZldTNtfWbxJq/8f/fge2pap60gn066ido2Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "10.57.0"
+				"@sentry/core": "10.58.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -4691,6 +4689,32 @@
 				"@opentelemetry/core": "^1.30.1 || ^2.1.0",
 				"@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
 				"@opentelemetry/semantic-conventions": "^1.39.0"
+			}
+		},
+		"node_modules/@sentry/replay": {
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.58.0.tgz",
+			"integrity": "sha512-EVasQNUenpwJksK9DI1TQ78YytpjLAhxn0UTiHqA3sU/s1fHK5XZdZJPr/9uEGedRoInIP0UIWmbOtOEX8HHDg==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/browser-utils": "10.58.0",
+				"@sentry/core": "10.58.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/replay-canvas": {
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.58.0.tgz",
+			"integrity": "sha512-ufFmaJ968DXGe6u9W/UqNVjCCTtAqT2bNtSu1jHAjIFFpWIuM80lcR33grK6SuGnFxceu5iJFaIW6JRyfbM0Sw==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/core": "10.58.0",
+				"@sentry/replay": "10.58.0"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@sentry/rollup-plugin": {
@@ -4714,14 +4738,26 @@
 				}
 			}
 		},
-		"node_modules/@sentry/svelte": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry/svelte/-/svelte-10.57.0.tgz",
-			"integrity": "sha512-24cToywNUF/S7YpHXcfHjfreJbMkxOFD8mXvi0VdjO/rTFvD2m9g8RXpqCGgG3UZ/Ym7KK3suPPTapRyLCwayA==",
+		"node_modules/@sentry/server-utils": {
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.58.0.tgz",
+			"integrity": "sha512-PywIl2jvl+tO5R4j+n72Lcf3ItanHcaMN/oL1U9ZHE8icaT2zpo2W4uOaslpQeQvqPC24HGZ3BW2etzsCFQbag==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/browser": "10.57.0",
-				"@sentry/core": "10.57.0",
+				"@sentry/core": "10.58.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/svelte": {
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/svelte/-/svelte-10.58.0.tgz",
+			"integrity": "sha512-cSTVVhoKTvawtjmYQ+Bbxxe4WdvPty6SvL3Z16DuD+ULsF4kksHiB6n45ma1r3fTnGKNvqAlUvMzynjzn2CLEw==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/browser": "10.58.0",
+				"@sentry/core": "10.58.0",
 				"magic-string": "~0.30.0"
 			},
 			"engines": {
@@ -4732,15 +4768,15 @@
 			}
 		},
 		"node_modules/@sentry/sveltekit": {
-			"version": "10.57.0",
-			"resolved": "https://registry.npmjs.org/@sentry/sveltekit/-/sveltekit-10.57.0.tgz",
-			"integrity": "sha512-079hOUb4aE0OBsqdD4HlPSnF7rViOubWly8/jpSpg33KeZCjAJ4cEaVdJHsJLwRUgxOFsbCTyyHYRMF3OkkIBw==",
+			"version": "10.58.0",
+			"resolved": "https://registry.npmjs.org/@sentry/sveltekit/-/sveltekit-10.58.0.tgz",
+			"integrity": "sha512-wdR3odIVyd5AumNW6O/Phwc8IYHbIk7FBu84dy5t9mAJ3bS6L5mIBNv8QcM3KaRHzYTU2PY7Q/mAR3kbdsYDrg==",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/cloudflare": "10.57.0",
-				"@sentry/core": "10.57.0",
-				"@sentry/node": "10.57.0",
-				"@sentry/svelte": "10.57.0",
+				"@sentry/cloudflare": "10.58.0",
+				"@sentry/core": "10.58.0",
+				"@sentry/node": "10.58.0",
+				"@sentry/svelte": "10.58.0",
 				"@sentry/vite-plugin": "^5.3.0",
 				"@sveltejs/acorn-typescript": "^1.0.9",
 				"acorn": "^8.14.0",
@@ -4838,9 +4874,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.64.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.64.0.tgz",
-			"integrity": "sha512-24MXA/xyugUqJd09DD4v4bLd4k7FaYhdBck/pTXiu3XFtDBcwXYpJc1SO1+lqdjkNBUo1r4eek5FS7cfzBQUmA==",
+			"version": "2.65.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.65.2.tgz",
+			"integrity": "sha512-ZIkyEmxT1gcq50Opn1ZIIx6vc/yt2zNN0rF5hS6op95gqHtNw8QMKDhjJI+RyjMcbvECRw+FzEeAoBe/MOz9AA==",
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
@@ -4918,49 +4954,49 @@
 			}
 		},
 		"node_modules/@tailwindcss/node": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
-			"integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+			"integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.5",
-				"enhanced-resolve": "^5.21.0",
-				"jiti": "^2.6.1",
+				"enhanced-resolve": "5.21.6",
+				"jiti": "^2.7.0",
 				"lightningcss": "1.32.0",
 				"magic-string": "^0.30.21",
 				"source-map-js": "^1.2.1",
-				"tailwindcss": "4.3.0"
+				"tailwindcss": "4.3.1"
 			}
 		},
 		"node_modules/@tailwindcss/oxide": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
-			"integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+			"integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 20"
 			},
 			"optionalDependencies": {
-				"@tailwindcss/oxide-android-arm64": "4.3.0",
-				"@tailwindcss/oxide-darwin-arm64": "4.3.0",
-				"@tailwindcss/oxide-darwin-x64": "4.3.0",
-				"@tailwindcss/oxide-freebsd-x64": "4.3.0",
-				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
-				"@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
-				"@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
-				"@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
-				"@tailwindcss/oxide-linux-x64-musl": "4.3.0",
-				"@tailwindcss/oxide-wasm32-wasi": "4.3.0",
-				"@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
-				"@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+				"@tailwindcss/oxide-android-arm64": "4.3.1",
+				"@tailwindcss/oxide-darwin-arm64": "4.3.1",
+				"@tailwindcss/oxide-darwin-x64": "4.3.1",
+				"@tailwindcss/oxide-freebsd-x64": "4.3.1",
+				"@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+				"@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+				"@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+				"@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+				"@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+				"@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+				"@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+				"@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
 			}
 		},
 		"node_modules/@tailwindcss/oxide-android-arm64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
-			"integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+			"integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -4975,9 +5011,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-darwin-arm64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
-			"integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+			"integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
 			"cpu": [
 				"arm64"
 			],
@@ -4992,9 +5028,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-darwin-x64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
-			"integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+			"integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
 			"cpu": [
 				"x64"
 			],
@@ -5009,9 +5045,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-freebsd-x64": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
-			"integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+			"integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
 			"cpu": [
 				"x64"
 			],
@@ -5026,9 +5062,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
-			"integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+			"integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
 			"cpu": [
 				"arm"
 			],
@@ -5043,9 +5079,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
-			"integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+			"integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -5063,9 +5099,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
-			"integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+			"integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
 			"cpu": [
 				"arm64"
 			],
@@ -5083,9 +5119,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
-			"integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+			"integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
 			"cpu": [
 				"x64"
 			],
@@ -5103,9 +5139,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-linux-x64-musl": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
-			"integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+			"integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
 			"cpu": [
 				"x64"
 			],
@@ -5123,9 +5159,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-wasm32-wasi": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
-			"integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+			"integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
 			"bundleDependencies": [
 				"@napi-rs/wasm-runtime",
 				"@emnapi/core",
@@ -5145,7 +5181,7 @@
 				"@emnapi/runtime": "^1.10.0",
 				"@emnapi/wasi-threads": "^1.2.1",
 				"@napi-rs/wasm-runtime": "^1.1.4",
-				"@tybys/wasm-util": "^0.10.1",
+				"@tybys/wasm-util": "^0.10.2",
 				"tslib": "^2.8.1"
 			},
 			"engines": {
@@ -5153,9 +5189,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
-			"integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+			"integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
 			"cpu": [
 				"arm64"
 			],
@@ -5170,9 +5206,9 @@
 			}
 		},
 		"node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
-			"integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+			"integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
 			"cpu": [
 				"x64"
 			],
@@ -5200,15 +5236,15 @@
 			}
 		},
 		"node_modules/@tailwindcss/vite": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
-			"integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.1.tgz",
+			"integrity": "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@tailwindcss/node": "4.3.0",
-				"@tailwindcss/oxide": "4.3.0",
-				"tailwindcss": "4.3.0"
+				"@tailwindcss/node": "4.3.1",
+				"@tailwindcss/oxide": "4.3.1",
+				"tailwindcss": "4.3.1"
 			},
 			"peerDependencies": {
 				"vite": "^5.2.0 || ^6 || ^7 || ^8"
@@ -5345,9 +5381,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.9.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-			"integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+			"version": "25.9.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+			"integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5454,14 +5490,14 @@
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
-			"integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+			"integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.8",
+				"@vitest/utils": "4.1.9",
 				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
@@ -5475,8 +5511,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.1.8",
-				"vitest": "4.1.8"
+				"@vitest/browser": "4.1.9",
+				"vitest": "4.1.9"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -5485,16 +5521,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-			"integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+			"integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.8",
-				"@vitest/utils": "4.1.8",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -5503,13 +5539,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-			"integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+			"integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.8",
+				"@vitest/spy": "4.1.9",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -5540,9 +5576,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-			"integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+			"integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5553,13 +5589,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-			"integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+			"integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.8",
+				"@vitest/utils": "4.1.9",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -5567,14 +5603,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-			"integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+			"integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.8",
-				"@vitest/utils": "4.1.8",
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -5583,9 +5619,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-			"integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+			"integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
 			"devOptional": true,
 			"license": "MIT",
 			"funding": {
@@ -5593,13 +5629,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-			"integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+			"integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.8",
+				"@vitest/pretty-format": "4.1.9",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -5608,9 +5644,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -5692,9 +5728,9 @@
 			}
 		},
 		"node_modules/arkregex": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/arkregex/-/arkregex-0.0.5.tgz",
-			"integrity": "sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==",
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/arkregex/-/arkregex-0.0.6.tgz",
+			"integrity": "sha512-9mvuMKQuibfWhBrsNYhsKhNb6k9oEHoAJ/FvDiqe8h+E9Siwe0/cro1WVOGgpajXQ9ZHd24yCOf2k35Q/QqUQw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -5703,16 +5739,16 @@
 			}
 		},
 		"node_modules/arktype": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/arktype/-/arktype-2.2.0.tgz",
-			"integrity": "sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/arktype/-/arktype-2.2.1.tgz",
+			"integrity": "sha512-CWPJxNoSxrS+NYGB3ufwc/blFonESEW5vBQyYPVS0rf4STu8VWoAWfKJSl5vVVm56h4yxpwbODeYwy6XFKvojA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"@ark/schema": "0.56.0",
 				"@ark/util": "0.56.0",
-				"arkregex": "0.0.5"
+				"arkregex": "0.0.6"
 			}
 		},
 		"node_modules/assertion-error": {
@@ -5800,9 +5836,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.35",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
-			"integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
+			"version": "2.10.38",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+			"integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
 			"license": "Apache-2.0",
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.cjs"
@@ -5812,20 +5848,20 @@
 			}
 		},
 		"node_modules/better-auth": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.16.tgz",
-			"integrity": "sha512-YlBITnH3LIBRD+JpR1XRIToJAVVpoQvZzRc4sm5W0/bnPZKLbsmtXbVWJF3ypo9TVnF6geczJKprG/CsWT07Wg==",
+			"version": "1.6.19",
+			"resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.19.tgz",
+			"integrity": "sha512-68eXWKj0sxa0xW4+n4tENd6Co94UCynPKe1fncmO6kIB3XhSXWgwDEpiUouJV2dmLBrHM1FPkoI6Q5597zCGpQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@better-auth/core": "1.6.16",
-				"@better-auth/drizzle-adapter": "1.6.16",
-				"@better-auth/kysely-adapter": "1.6.16",
-				"@better-auth/memory-adapter": "1.6.16",
-				"@better-auth/mongo-adapter": "1.6.16",
-				"@better-auth/prisma-adapter": "1.6.16",
-				"@better-auth/telemetry": "1.6.16",
-				"@better-auth/utils": "0.4.1",
-				"@better-fetch/fetch": "1.2.2",
+				"@better-auth/core": "1.6.19",
+				"@better-auth/drizzle-adapter": "1.6.19",
+				"@better-auth/kysely-adapter": "1.6.19",
+				"@better-auth/memory-adapter": "1.6.19",
+				"@better-auth/mongo-adapter": "1.6.19",
+				"@better-auth/prisma-adapter": "1.6.19",
+				"@better-auth/telemetry": "1.6.19",
+				"@better-auth/utils": "0.4.2",
+				"@better-fetch/fetch": "1.3.1",
 				"@noble/ciphers": "^2.1.1",
 				"@noble/hashes": "^2.0.1",
 				"better-call": "1.3.6",
@@ -5937,9 +5973,9 @@
 			}
 		},
 		"node_modules/better-sqlite3": {
-			"version": "12.10.0",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-			"integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+			"version": "12.11.1",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+			"integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6085,9 +6121,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001797",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
-			"integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+			"version": "1.0.30001799",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+			"integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7516,9 +7552,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.371",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
-			"integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
+			"version": "1.5.375",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
+			"integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
 			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
@@ -7538,9 +7574,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.23.0",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz",
-			"integrity": "sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==",
+			"version": "5.21.6",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+			"integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7582,9 +7618,9 @@
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-			"integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -7594,32 +7630,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.28.0",
-				"@esbuild/android-arm": "0.28.0",
-				"@esbuild/android-arm64": "0.28.0",
-				"@esbuild/android-x64": "0.28.0",
-				"@esbuild/darwin-arm64": "0.28.0",
-				"@esbuild/darwin-x64": "0.28.0",
-				"@esbuild/freebsd-arm64": "0.28.0",
-				"@esbuild/freebsd-x64": "0.28.0",
-				"@esbuild/linux-arm": "0.28.0",
-				"@esbuild/linux-arm64": "0.28.0",
-				"@esbuild/linux-ia32": "0.28.0",
-				"@esbuild/linux-loong64": "0.28.0",
-				"@esbuild/linux-mips64el": "0.28.0",
-				"@esbuild/linux-ppc64": "0.28.0",
-				"@esbuild/linux-riscv64": "0.28.0",
-				"@esbuild/linux-s390x": "0.28.0",
-				"@esbuild/linux-x64": "0.28.0",
-				"@esbuild/netbsd-arm64": "0.28.0",
-				"@esbuild/netbsd-x64": "0.28.0",
-				"@esbuild/openbsd-arm64": "0.28.0",
-				"@esbuild/openbsd-x64": "0.28.0",
-				"@esbuild/openharmony-arm64": "0.28.0",
-				"@esbuild/sunos-x64": "0.28.0",
-				"@esbuild/win32-arm64": "0.28.0",
-				"@esbuild/win32-ia32": "0.28.0",
-				"@esbuild/win32-x64": "0.28.0"
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
 			}
 		},
 		"node_modules/escalade": {
@@ -7688,9 +7724,9 @@
 			}
 		},
 		"node_modules/fallow": {
-			"version": "2.91.0",
-			"resolved": "https://registry.npmjs.org/fallow/-/fallow-2.91.0.tgz",
-			"integrity": "sha512-DHf+w30Z6Kt1JRg83rl27TaNJHTs09W7Egtal7CxIkz8pSMZNpryLpvIzh+41MMrPzJRA1q8r81umdNdZFoxzw==",
+			"version": "2.98.0",
+			"resolved": "https://registry.npmjs.org/fallow/-/fallow-2.98.0.tgz",
+			"integrity": "sha512-6n7CZjXyvkRzv30kkGwG+JNK/t/jWPUU9J8wMIN4uo4GpGrrBFtW+c9SJ9DSDAR7TZrQs2u/pMykpSrxpCGMjA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7705,14 +7741,14 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@fallow-cli/darwin-arm64": "2.91.0",
-				"@fallow-cli/darwin-x64": "2.91.0",
-				"@fallow-cli/linux-arm64-gnu": "2.91.0",
-				"@fallow-cli/linux-arm64-musl": "2.91.0",
-				"@fallow-cli/linux-x64-gnu": "2.91.0",
-				"@fallow-cli/linux-x64-musl": "2.91.0",
-				"@fallow-cli/win32-arm64-msvc": "2.91.0",
-				"@fallow-cli/win32-x64-msvc": "2.91.0"
+				"@fallow-cli/darwin-arm64": "2.98.0",
+				"@fallow-cli/darwin-x64": "2.98.0",
+				"@fallow-cli/linux-arm64-gnu": "2.98.0",
+				"@fallow-cli/linux-arm64-musl": "2.98.0",
+				"@fallow-cli/linux-x64-gnu": "2.98.0",
+				"@fallow-cli/linux-x64-musl": "2.98.0",
+				"@fallow-cli/win32-arm64-msvc": "2.98.0",
+				"@fallow-cli/win32-x64-msvc": "2.98.0"
 			}
 		},
 		"node_modules/fast-check": {
@@ -8060,9 +8096,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/import-in-the-middle": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.2.tgz",
-			"integrity": "sha512-LGLYRl0A2gtyUJb2WDliBHmk6TtlHwdDjxonacZ8QrEs/ZW+YDgNv2QAfjRQWpS8HqvNcq6GGnN6jrOa5FysDQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.1.0.tgz",
+			"integrity": "sha512-c0AeAV8VcwZzfYE7euTZY3H+VXUPMVugiovdosq80lqEXJmOekg3zGUAYg6KImHMaMuBoTUfTv7xNpUFdy0hJA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"acorn": "^8.15.0",
@@ -8251,9 +8287,9 @@
 			}
 		},
 		"node_modules/joi": {
-			"version": "17.13.3",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-			"integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+			"version": "17.13.4",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+			"integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"optional": true,
@@ -8329,9 +8365,9 @@
 			}
 		},
 		"node_modules/knip": {
-			"version": "6.16.1",
-			"resolved": "https://registry.npmjs.org/knip/-/knip-6.16.1.tgz",
-			"integrity": "sha512-TKMn1rxgH6h9vXR9Y0B+Cq7AdPTr9EI02IwoT65NzqYUkvoDQAaJ/aPybiFpAhZ1px6cNYYwXf86iHkBgzCo9w==",
+			"version": "6.17.1",
+			"resolved": "https://registry.npmjs.org/knip/-/knip-6.17.1.tgz",
+			"integrity": "sha512-HcQsZSQ4Ymhuay4BVzJtM5pFZNDSomYYqcNCZOSITPQh9g18a09DqziWAxSt2G+BH9wGlG+0ZjWpEnaFlnKseQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8349,13 +8385,13 @@
 				"formatly": "^0.3.0",
 				"get-tsconfig": "4.14.0",
 				"jiti": "^2.7.0",
-				"oxc-parser": "^0.133.0",
+				"oxc-parser": "^0.135.0",
 				"oxc-resolver": "^11.20.0",
 				"picomatch": "^4.0.4",
 				"smol-toml": "^1.6.1",
 				"strip-json-comments": "5.0.3",
-				"tinyglobby": "^0.2.16",
-				"unbash": "^3.0.0",
+				"tinyglobby": "^0.2.17",
+				"unbash": "^4.0.1",
 				"yaml": "^2.9.0",
 				"zod": "^4.1.11"
 			},
@@ -9406,9 +9442,9 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
-			"integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
 			"funding": [
 				"https://github.com/sponsors/sxzz",
 				"https://opencollective.com/debug"
@@ -9444,13 +9480,13 @@
 			}
 		},
 		"node_modules/oxc-parser": {
-			"version": "0.133.0",
-			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.133.0.tgz",
-			"integrity": "sha512-661RSx+ZcjBmjBYid+Fpp/2F5EbtildpeoZh5HdgnGs+jZ03nqQEQW8yGkt4BGyOC3OMPDQQRl8M5kqD2/g6jw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.135.0.tgz",
+			"integrity": "sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "^0.133.0"
+				"@oxc-project/types": "^0.135.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
@@ -9459,57 +9495,57 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxc-parser/binding-android-arm-eabi": "0.133.0",
-				"@oxc-parser/binding-android-arm64": "0.133.0",
-				"@oxc-parser/binding-darwin-arm64": "0.133.0",
-				"@oxc-parser/binding-darwin-x64": "0.133.0",
-				"@oxc-parser/binding-freebsd-x64": "0.133.0",
-				"@oxc-parser/binding-linux-arm-gnueabihf": "0.133.0",
-				"@oxc-parser/binding-linux-arm-musleabihf": "0.133.0",
-				"@oxc-parser/binding-linux-arm64-gnu": "0.133.0",
-				"@oxc-parser/binding-linux-arm64-musl": "0.133.0",
-				"@oxc-parser/binding-linux-ppc64-gnu": "0.133.0",
-				"@oxc-parser/binding-linux-riscv64-gnu": "0.133.0",
-				"@oxc-parser/binding-linux-riscv64-musl": "0.133.0",
-				"@oxc-parser/binding-linux-s390x-gnu": "0.133.0",
-				"@oxc-parser/binding-linux-x64-gnu": "0.133.0",
-				"@oxc-parser/binding-linux-x64-musl": "0.133.0",
-				"@oxc-parser/binding-openharmony-arm64": "0.133.0",
-				"@oxc-parser/binding-wasm32-wasi": "0.133.0",
-				"@oxc-parser/binding-win32-arm64-msvc": "0.133.0",
-				"@oxc-parser/binding-win32-ia32-msvc": "0.133.0",
-				"@oxc-parser/binding-win32-x64-msvc": "0.133.0"
+				"@oxc-parser/binding-android-arm-eabi": "0.135.0",
+				"@oxc-parser/binding-android-arm64": "0.135.0",
+				"@oxc-parser/binding-darwin-arm64": "0.135.0",
+				"@oxc-parser/binding-darwin-x64": "0.135.0",
+				"@oxc-parser/binding-freebsd-x64": "0.135.0",
+				"@oxc-parser/binding-linux-arm-gnueabihf": "0.135.0",
+				"@oxc-parser/binding-linux-arm-musleabihf": "0.135.0",
+				"@oxc-parser/binding-linux-arm64-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-arm64-musl": "0.135.0",
+				"@oxc-parser/binding-linux-ppc64-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-riscv64-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-riscv64-musl": "0.135.0",
+				"@oxc-parser/binding-linux-s390x-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-x64-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-x64-musl": "0.135.0",
+				"@oxc-parser/binding-openharmony-arm64": "0.135.0",
+				"@oxc-parser/binding-wasm32-wasi": "0.135.0",
+				"@oxc-parser/binding-win32-arm64-msvc": "0.135.0",
+				"@oxc-parser/binding-win32-ia32-msvc": "0.135.0",
+				"@oxc-parser/binding-win32-x64-msvc": "0.135.0"
 			}
 		},
 		"node_modules/oxc-resolver": {
-			"version": "11.20.0",
-			"resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.20.0.tgz",
-			"integrity": "sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==",
+			"version": "11.21.2",
+			"resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.21.2.tgz",
+			"integrity": "sha512-w5tLwYN3Zo24w5EeWJjJWZOwhYqTtC8PS2B1tIt7BZUuqTIcU07sQValbDw+rq7+AuAGzOHklgK+ifsy4lpXfw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxc-resolver/binding-android-arm-eabi": "11.20.0",
-				"@oxc-resolver/binding-android-arm64": "11.20.0",
-				"@oxc-resolver/binding-darwin-arm64": "11.20.0",
-				"@oxc-resolver/binding-darwin-x64": "11.20.0",
-				"@oxc-resolver/binding-freebsd-x64": "11.20.0",
-				"@oxc-resolver/binding-linux-arm-gnueabihf": "11.20.0",
-				"@oxc-resolver/binding-linux-arm-musleabihf": "11.20.0",
-				"@oxc-resolver/binding-linux-arm64-gnu": "11.20.0",
-				"@oxc-resolver/binding-linux-arm64-musl": "11.20.0",
-				"@oxc-resolver/binding-linux-ppc64-gnu": "11.20.0",
-				"@oxc-resolver/binding-linux-riscv64-gnu": "11.20.0",
-				"@oxc-resolver/binding-linux-riscv64-musl": "11.20.0",
-				"@oxc-resolver/binding-linux-s390x-gnu": "11.20.0",
-				"@oxc-resolver/binding-linux-x64-gnu": "11.20.0",
-				"@oxc-resolver/binding-linux-x64-musl": "11.20.0",
-				"@oxc-resolver/binding-openharmony-arm64": "11.20.0",
-				"@oxc-resolver/binding-wasm32-wasi": "11.20.0",
-				"@oxc-resolver/binding-win32-arm64-msvc": "11.20.0",
-				"@oxc-resolver/binding-win32-x64-msvc": "11.20.0"
+				"@oxc-resolver/binding-android-arm-eabi": "11.21.2",
+				"@oxc-resolver/binding-android-arm64": "11.21.2",
+				"@oxc-resolver/binding-darwin-arm64": "11.21.2",
+				"@oxc-resolver/binding-darwin-x64": "11.21.2",
+				"@oxc-resolver/binding-freebsd-x64": "11.21.2",
+				"@oxc-resolver/binding-linux-arm-gnueabihf": "11.21.2",
+				"@oxc-resolver/binding-linux-arm-musleabihf": "11.21.2",
+				"@oxc-resolver/binding-linux-arm64-gnu": "11.21.2",
+				"@oxc-resolver/binding-linux-arm64-musl": "11.21.2",
+				"@oxc-resolver/binding-linux-ppc64-gnu": "11.21.2",
+				"@oxc-resolver/binding-linux-riscv64-gnu": "11.21.2",
+				"@oxc-resolver/binding-linux-riscv64-musl": "11.21.2",
+				"@oxc-resolver/binding-linux-s390x-gnu": "11.21.2",
+				"@oxc-resolver/binding-linux-x64-gnu": "11.21.2",
+				"@oxc-resolver/binding-linux-x64-musl": "11.21.2",
+				"@oxc-resolver/binding-openharmony-arm64": "11.21.2",
+				"@oxc-resolver/binding-wasm32-wasi": "11.21.2",
+				"@oxc-resolver/binding-win32-arm64-msvc": "11.21.2",
+				"@oxc-resolver/binding-win32-x64-msvc": "11.21.2"
 			}
 		},
 		"node_modules/oxfmt": {
@@ -9565,9 +9601,9 @@
 			}
 		},
 		"node_modules/oxlint": {
-			"version": "1.69.0",
-			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.69.0.tgz",
-			"integrity": "sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.70.0.tgz",
+			"integrity": "sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -9580,25 +9616,25 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxlint/binding-android-arm-eabi": "1.69.0",
-				"@oxlint/binding-android-arm64": "1.69.0",
-				"@oxlint/binding-darwin-arm64": "1.69.0",
-				"@oxlint/binding-darwin-x64": "1.69.0",
-				"@oxlint/binding-freebsd-x64": "1.69.0",
-				"@oxlint/binding-linux-arm-gnueabihf": "1.69.0",
-				"@oxlint/binding-linux-arm-musleabihf": "1.69.0",
-				"@oxlint/binding-linux-arm64-gnu": "1.69.0",
-				"@oxlint/binding-linux-arm64-musl": "1.69.0",
-				"@oxlint/binding-linux-ppc64-gnu": "1.69.0",
-				"@oxlint/binding-linux-riscv64-gnu": "1.69.0",
-				"@oxlint/binding-linux-riscv64-musl": "1.69.0",
-				"@oxlint/binding-linux-s390x-gnu": "1.69.0",
-				"@oxlint/binding-linux-x64-gnu": "1.69.0",
-				"@oxlint/binding-linux-x64-musl": "1.69.0",
-				"@oxlint/binding-openharmony-arm64": "1.69.0",
-				"@oxlint/binding-win32-arm64-msvc": "1.69.0",
-				"@oxlint/binding-win32-ia32-msvc": "1.69.0",
-				"@oxlint/binding-win32-x64-msvc": "1.69.0"
+				"@oxlint/binding-android-arm-eabi": "1.70.0",
+				"@oxlint/binding-android-arm64": "1.70.0",
+				"@oxlint/binding-darwin-arm64": "1.70.0",
+				"@oxlint/binding-darwin-x64": "1.70.0",
+				"@oxlint/binding-freebsd-x64": "1.70.0",
+				"@oxlint/binding-linux-arm-gnueabihf": "1.70.0",
+				"@oxlint/binding-linux-arm-musleabihf": "1.70.0",
+				"@oxlint/binding-linux-arm64-gnu": "1.70.0",
+				"@oxlint/binding-linux-arm64-musl": "1.70.0",
+				"@oxlint/binding-linux-ppc64-gnu": "1.70.0",
+				"@oxlint/binding-linux-riscv64-gnu": "1.70.0",
+				"@oxlint/binding-linux-riscv64-musl": "1.70.0",
+				"@oxlint/binding-linux-s390x-gnu": "1.70.0",
+				"@oxlint/binding-linux-x64-gnu": "1.70.0",
+				"@oxlint/binding-linux-x64-musl": "1.70.0",
+				"@oxlint/binding-openharmony-arm64": "1.70.0",
+				"@oxlint/binding-win32-arm64-msvc": "1.70.0",
+				"@oxlint/binding-win32-ia32-msvc": "1.70.0",
+				"@oxlint/binding-win32-x64-msvc": "1.70.0"
 			},
 			"peerDependencies": {
 				"oxlint-tsgolint": ">=0.22.1",
@@ -9929,9 +9965,9 @@
 			}
 		},
 		"node_modules/resend": {
-			"version": "6.12.4",
-			"resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
-			"integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/resend/-/resend-6.14.0.tgz",
+			"integrity": "sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA==",
 			"license": "MIT",
 			"dependencies": {
 				"postal-mime": "2.7.4",
@@ -10044,10 +10080,19 @@
 				"@rolldown/binding-win32-x64-msvc": "1.0.3"
 			}
 		},
+		"node_modules/rolldown/node_modules/@oxc-project/types": {
+			"version": "0.133.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+			"integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
 		"node_modules/rollup": {
-			"version": "4.61.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
-			"integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+			"version": "4.62.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+			"integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10061,31 +10106,31 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.61.1",
-				"@rollup/rollup-android-arm64": "4.61.1",
-				"@rollup/rollup-darwin-arm64": "4.61.1",
-				"@rollup/rollup-darwin-x64": "4.61.1",
-				"@rollup/rollup-freebsd-arm64": "4.61.1",
-				"@rollup/rollup-freebsd-x64": "4.61.1",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
-				"@rollup/rollup-linux-arm-musleabihf": "4.61.1",
-				"@rollup/rollup-linux-arm64-gnu": "4.61.1",
-				"@rollup/rollup-linux-arm64-musl": "4.61.1",
-				"@rollup/rollup-linux-loong64-gnu": "4.61.1",
-				"@rollup/rollup-linux-loong64-musl": "4.61.1",
-				"@rollup/rollup-linux-ppc64-gnu": "4.61.1",
-				"@rollup/rollup-linux-ppc64-musl": "4.61.1",
-				"@rollup/rollup-linux-riscv64-gnu": "4.61.1",
-				"@rollup/rollup-linux-riscv64-musl": "4.61.1",
-				"@rollup/rollup-linux-s390x-gnu": "4.61.1",
-				"@rollup/rollup-linux-x64-gnu": "4.61.1",
-				"@rollup/rollup-linux-x64-musl": "4.61.1",
-				"@rollup/rollup-openbsd-x64": "4.61.1",
-				"@rollup/rollup-openharmony-arm64": "4.61.1",
-				"@rollup/rollup-win32-arm64-msvc": "4.61.1",
-				"@rollup/rollup-win32-ia32-msvc": "4.61.1",
-				"@rollup/rollup-win32-x64-gnu": "4.61.1",
-				"@rollup/rollup-win32-x64-msvc": "4.61.1",
+				"@rollup/rollup-android-arm-eabi": "4.62.0",
+				"@rollup/rollup-android-arm64": "4.62.0",
+				"@rollup/rollup-darwin-arm64": "4.62.0",
+				"@rollup/rollup-darwin-x64": "4.62.0",
+				"@rollup/rollup-freebsd-arm64": "4.62.0",
+				"@rollup/rollup-freebsd-x64": "4.62.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.62.0",
+				"@rollup/rollup-linux-arm64-musl": "4.62.0",
+				"@rollup/rollup-linux-loong64-gnu": "4.62.0",
+				"@rollup/rollup-linux-loong64-musl": "4.62.0",
+				"@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+				"@rollup/rollup-linux-ppc64-musl": "4.62.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+				"@rollup/rollup-linux-riscv64-musl": "4.62.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.62.0",
+				"@rollup/rollup-linux-x64-gnu": "4.62.0",
+				"@rollup/rollup-linux-x64-musl": "4.62.0",
+				"@rollup/rollup-openbsd-x64": "4.62.0",
+				"@rollup/rollup-openharmony-arm64": "4.62.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.62.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.62.0",
+				"@rollup/rollup-win32-x64-gnu": "4.62.0",
+				"@rollup/rollup-win32-x64-msvc": "4.62.0",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -10750,9 +10795,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-			"integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+			"integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10972,17 +11017,17 @@
 			}
 		},
 		"node_modules/typebox": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.2.8.tgz",
-			"integrity": "sha512-rlsKhsd7L3082m9nxhFIB4Gl8jizLd/6YlFAWaz96hdV8+VJRjwYaYmDlT0jlTRwkb48SxCSSirqUtrg/HilNw==",
+			"version": "1.2.16",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.2.16.tgz",
+			"integrity": "sha512-p85YWtR1RznP2kt/sftmj1leGiObfHVJwkK2hkDdEKhbtQONeUeBtbYdK0x9tLPh+5AaEPD62APv189Cy+/C2g==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -10994,9 +11039,9 @@
 			}
 		},
 		"node_modules/unbash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unbash/-/unbash-3.0.0.tgz",
-			"integrity": "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.1.tgz",
+			"integrity": "sha512-1ajSo3813sDoVIHx4inJdUS4l5L2ic5cFiddemPiyjb/PZEoBAhFwHtbaEdRDFxbAKy7FCG7s5ww3/uCFawuIA==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
@@ -11170,19 +11215,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+			"integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.8",
-				"@vitest/mocker": "4.1.8",
-				"@vitest/pretty-format": "4.1.8",
-				"@vitest/runner": "4.1.8",
-				"@vitest/snapshot": "4.1.8",
-				"@vitest/spy": "4.1.8",
-				"@vitest/utils": "4.1.8",
+				"@vitest/expect": "4.1.9",
+				"@vitest/mocker": "4.1.9",
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/runner": "4.1.9",
+				"@vitest/snapshot": "4.1.9",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -11210,12 +11255,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.8",
-				"@vitest/browser-preview": "4.1.8",
-				"@vitest/browser-webdriverio": "4.1.8",
-				"@vitest/coverage-istanbul": "4.1.8",
-				"@vitest/coverage-v8": "4.1.8",
-				"@vitest/ui": "4.1.8",
+				"@vitest/browser-playwright": "4.1.9",
+				"@vitest/browser-preview": "4.1.9",
+				"@vitest/browser-webdriverio": "4.1.9",
+				"@vitest/coverage-istanbul": "4.1.9",
+				"@vitest/coverage-v8": "4.1.9",
+				"@vitest/ui": "4.1.9",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 	"devDependencies": {
 		"@flydotio/dockerfile": "^0.7.10",
 		"@internationalized/date": "^3.12.1",
-		"@lucide/svelte": "^1.7.0",
+		"@lucide/svelte": "^1.20.0",
 		"@sveltejs/adapter-node": "^5.4.0",
 		"@sveltejs/kit": "^2.49.2",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
@@ -77,7 +77,7 @@
 		"tailwind-variants": "^3.2.2",
 		"tailwindcss": "^4.1.18",
 		"tw-animate-css": "^1.4.0",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vite": "^8.0.13",
 		"vitest": "^4.1.6",
 		"zod": "^4.4.3"

--- a/src/routes/(app)/finances/budget/+page.server.ts
+++ b/src/routes/(app)/finances/budget/+page.server.ts
@@ -1,7 +1,7 @@
 import { budgetSchema } from '$lib/formSchemas';
 import { requireAuth } from '$lib/server/actions/auth-guard';
 import { getDb } from '$lib/server/db';
-import { budgetQueries, categoryQueries, recurringQueries } from '$lib/server/db/queries';
+import { budgetQueries, recurringQueries } from '$lib/server/db/queries';
 import { budget, transaction } from '$lib/server/db/schema';
 import { withAuditFieldsForCreate, withAuditFieldsForUpdate } from '$lib/server/db/utils';
 import { logger } from '$lib/server/logger';
@@ -98,7 +98,6 @@ export const load: PageServerLoad = async ({ url }) => {
 		historicalBudgets,
 		historicalTransactions,
 		last6Months,
-		categories: await categoryQueries.findAll(),
 		recurring: await recurringQueries.findAll(),
 		form
 	};

--- a/src/routes/(app)/finances/income/+page.server.ts
+++ b/src/routes/(app)/finances/income/+page.server.ts
@@ -10,7 +10,7 @@ import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url }) => {
 	// Get month, year, and date range from URL params or use current month/year
-	const { month, year, startDate, endDate } = getMonthRangeFromUrl(url);
+	const { year, startDate, endDate } = getMonthRangeFromUrl(url);
 
 	// Get yearly date range
 	const { startDate: yearStartDate, endDate: yearEndDate } = getYearDateRange(year);
@@ -38,8 +38,6 @@ export const load: PageServerLoad = async ({ url }) => {
 		monthlyIncomes,
 		yearlyIncomes,
 		completedMonthsSinceJanuary,
-		month,
-		year,
 		form
 	};
 };

--- a/src/routes/(app)/receipts/business/+page.server.ts
+++ b/src/routes/(app)/receipts/business/+page.server.ts
@@ -5,7 +5,7 @@ import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url, parent }) => {
 	const { categories } = await parent();
-	const { gasCategory, month, year, startDate, endDate, yearStartDate, yearEndDate, form } =
+	const { gasCategory, startDate, endDate, yearStartDate, yearEndDate, form } =
 		await getReceiptLoadContext(url, categories);
 
 	const [monthlyTransactions, yearlyTransactions] = await Promise.all([
@@ -18,7 +18,7 @@ export const load: PageServerLoad = async ({ url, parent }) => {
 		)
 	]);
 
-	return { monthlyTransactions, yearlyTransactions, month, year, form };
+	return { monthlyTransactions, yearlyTransactions, form };
 };
 
 export { receiptActions as actions } from '$lib/server/receipts/load-helpers';

--- a/src/routes/(app)/receipts/fuel/+page.server.ts
+++ b/src/routes/(app)/receipts/fuel/+page.server.ts
@@ -5,7 +5,7 @@ import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url, parent }) => {
 	const { categories } = await parent();
-	const { gasCategory, month, year, startDate, endDate, yearStartDate, yearEndDate, form } =
+	const { gasCategory, year, startDate, endDate, yearStartDate, yearEndDate, form } =
 		await getReceiptLoadContext(url, categories);
 
 	const currentDate = new Date();
@@ -25,8 +25,6 @@ export const load: PageServerLoad = async ({ url, parent }) => {
 		monthlyTransactions,
 		yearlyTransactions,
 		completedMonthsSinceJanuary,
-		month,
-		year,
 		form
 	};
 };


### PR DESCRIPTION
Update TypeScript to version 6.0.3 and update the @lucide/svelte dependency to version 1.20.0. Additionally, remove unused imports related to categories in several load functions.