### PR TITLE
Implement password reset URL validation and logging for untrusted origins

### DIFF
--- a/src/lib/server/auth-reset-url.test.ts
+++ b/src/lib/server/auth-reset-url.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockLoggerWarn = vi.hoisted(() => vi.fn<() => void>());
+
+vi.mock('$app/env/private', () => ({
+	BETTER_AUTH_BASE_URL: 'https://sheppakai-budget.fly.dev',
+	NODE_ENV: 'production'
+}));
+
+vi.mock('./logger', () => ({
+	logger: {
+		warn: mockLoggerWarn,
+		info: vi.fn<() => void>(),
+		debug: vi.fn<() => void>(),
+		error: vi.fn<() => void>()
+	}
+}));
+
+import { buildResetUrl } from './auth-reset-url';
+
+const ALLOWED_ORIGIN = 'https://sheppakai-budget.fly.dev';
+const TOKEN = 'abc123resettoken';
+
+describe('buildResetUrl', () => {
+	describe('valid allowed origin', () => {
+		it('returns a URL string for an allowed origin', () => {
+			const result = buildResetUrl(`${ALLOWED_ORIGIN}/auth/reset-password`, TOKEN);
+			expect(result).toBeTypeOf('string');
+		});
+
+		it('appends the token via searchParams (no double question mark)', () => {
+			const result = buildResetUrl(`${ALLOWED_ORIGIN}/auth/reset-password`, TOKEN);
+			const url = new URL(result);
+			expect(url.searchParams.get('token')).toBe(TOKEN);
+			expect(result.split('?').length).toBe(2);
+		});
+
+		it('overwrites an existing token param rather than duplicating it', () => {
+			const callbackURL = `${ALLOWED_ORIGIN}/auth/reset-password?token=oldtoken`;
+			const result = buildResetUrl(callbackURL, TOKEN);
+			const url = new URL(result);
+			expect(url.searchParams.get('token')).toBe(TOKEN);
+			expect(url.searchParams.getAll('token')).toHaveLength(1);
+		});
+
+		it('preserves existing non-token query params', () => {
+			const callbackURL = `${ALLOWED_ORIGIN}/auth/reset-password?redirect=%2Fdashboard`;
+			const result = buildResetUrl(callbackURL, TOKEN);
+			const url = new URL(result);
+			expect(url.searchParams.get('redirect')).toBe('/dashboard');
+			expect(url.searchParams.get('token')).toBe(TOKEN);
+		});
+
+		it('does not call logger.warn for a trusted origin', () => {
+			buildResetUrl(`${ALLOWED_ORIGIN}/auth/reset-password`, TOKEN);
+			expect(mockLoggerWarn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('malformed URL', () => {
+		it('throws for a non-URL string', () => {
+			expect(() => buildResetUrl('not-a-url', TOKEN)).toThrow(
+				'Invalid callbackURL: not a valid URL'
+			);
+		});
+
+		it('throws for an empty string', () => {
+			expect(() => buildResetUrl('', TOKEN)).toThrow('Invalid callbackURL: not a valid URL');
+		});
+	});
+
+	describe('untrusted origin', () => {
+		it('throws for an attacker-controlled origin', () => {
+			expect(() => buildResetUrl('https://evil.example.com/steal', TOKEN)).toThrow(
+				'Untrusted callbackURL origin: https://evil.example.com'
+			);
+		});
+
+		it('throws for an origin that only partially matches the allowlist', () => {
+			expect(() => buildResetUrl('https://sheppakai-budget.fly.dev.evil.com/reset', TOKEN)).toThrow(
+				'Untrusted callbackURL origin'
+			);
+		});
+
+		it('throws for http variant of the production origin', () => {
+			expect(() =>
+				buildResetUrl('http://sheppakai-budget.fly.dev/auth/reset-password', TOKEN)
+			).toThrow('Untrusted callbackURL origin: http://sheppakai-budget.fly.dev');
+		});
+
+		it('calls logger.warn with the blocked origin', () => {
+			try {
+				buildResetUrl('https://evil.example.com/steal', TOKEN);
+			} catch {
+				// expected
+			}
+			expect(mockLoggerWarn).toHaveBeenCalledWith(
+				'Password reset blocked: untrusted callbackURL origin',
+				{ origin: 'https://evil.example.com' }
+			);
+		});
+	});
+});

--- a/src/lib/server/auth-reset-url.ts
+++ b/src/lib/server/auth-reset-url.ts
@@ -1,0 +1,38 @@
+import { BETTER_AUTH_BASE_URL, NODE_ENV } from '$app/env/private';
+
+import { logger } from './logger';
+
+/**
+ * Allowlisted origins for password-reset callback URLs.
+ * The callbackURL from the reset request is validated against this list
+ * before the token is appended, preventing open-redirect token leakage.
+ */
+const ALLOWED_RESET_ORIGINS = new Set([
+	new URL(BETTER_AUTH_BASE_URL).origin,
+	...(NODE_ENV === 'development' ? ['http://localhost:5173'] : [])
+]);
+
+/**
+ * Validates `callbackURL` against the allowed-origins allowlist and returns
+ * a safe reset URL with the token appended via searchParams.
+ *
+ * @throws if `callbackURL` is not a valid URL or its origin is not in the allowlist.
+ */
+export function buildResetUrl(callbackURL: string, token: string): string {
+	let parsed: URL;
+	try {
+		parsed = new URL(callbackURL);
+	} catch {
+		throw new Error('Invalid callbackURL: not a valid URL');
+	}
+
+	if (!ALLOWED_RESET_ORIGINS.has(parsed.origin)) {
+		logger.warn('Password reset blocked: untrusted callbackURL origin', {
+			origin: parsed.origin
+		});
+		throw new Error(`Untrusted callbackURL origin: ${parsed.origin}`);
+	}
+
+	parsed.searchParams.set('token', token);
+	return parsed.toString();
+}

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -12,6 +12,7 @@ import { APIError, createAuthMiddleware } from 'better-auth/api';
 import { admin } from 'better-auth/plugins';
 import { sveltekitCookies } from 'better-auth/svelte-kit';
 
+import { buildResetUrl } from './auth-reset-url';
 import { getDb } from './db';
 import * as schema from './db/schema';
 import {
@@ -51,13 +52,13 @@ export const auth = betterAuth({
 		revokeSessionsOnPasswordReset: true,
 		resetPasswordTokenExpiresIn: 60 * 10, // 10 minutes
 		sendResetPassword: async ({ user, url, token }) => {
-			// Construct the reset URL with token
-			const urlObj = new URL(url, 'http://localhost'); // Need a base for relative URLs
+			// Extract and validate callbackURL before building reset link
+			const urlObj = new URL(url);
 			const callbackURL = urlObj.searchParams.get('callbackURL');
 			if (!callbackURL) {
 				throw new Error('Missing callbackURL parameter');
 			}
-			const resetUrl = `${callbackURL}?token=${token}`;
+			const resetUrl = buildResetUrl(callbackURL, token);
 			void sendPasswordResetEmail(user.email, user.name || user.email, resetUrl);
 		},
 		onPasswordReset: async ({ user }) => {
@@ -162,7 +163,7 @@ export const auth = betterAuth({
 		}
 	},
 	trustedOrigins: [
-		'https://sheppakai-budget.fly.dev',
+		new URL(BETTER_AUTH_BASE_URL).origin,
 		...(NODE_ENV === 'development' ? ['http://localhost:5173'] : [])
 	],
 	rateLimit: {


### PR DESCRIPTION
Enhance security by validating password reset callback URLs against an allowlist and logging attempts from untrusted origins. This change prevents potential open-redirect vulnerabilities and ensures only trusted origins can generate reset URLs.