### PR TITLE
Revert version to 0.0.1 and update CSP directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sheppakai-budget",
-	"version": "0.0.2",
+	"version": "0.0.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -15,11 +15,14 @@ const config = {
 			mode: 'nonce',
 			directives: {
 				'default-src': ['self'],
-				// unsafe-eval is required by layerchart/d3 (Function constructor / eval use).
 				// unsafe-inline is intentionally absent — replaced by the per-request nonce.
-				'script-src': ['self', 'unsafe-eval'],
-				// unsafe-inline retained: Svelte injects inline <style> during SSR for scoped CSS.
-				'style-src': ['self', 'unsafe-inline'],
+				// unsafe-eval is not included: layerchart/d3-scale/d3-shape do not use
+				// Function() or eval(); d3-dsv (which does) is never imported.
+				'script-src': ['self'],
+				// unsafe-inline is absent: SvelteKit nonce mode injects a nonce attribute
+				// onto every <style> element it renders during SSR, so inline styles
+				// are covered by the nonce rather than the blanket unsafe-inline.
+				'style-src': ['self'],
 				'img-src': ['self', 'data:', 'https:'],
 				'font-src': ['self'],
 				'connect-src': ['self', 'https://*.ingest.us.sentry.io', 'https://*.ingest.sentry.io'],


### PR DESCRIPTION
Revert the package version to 0.0.1 and enhance CSP directives in the Svelte configuration by removing unsafe-eval and unsafe-inline, improving security.