### PR TITLE
Remove health check configuration from fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -22,14 +22,7 @@ primary_region = 'yyz'
   auto_start_machines = true
   min_machines_running = 0
   processes = ['app']
-
-  [[http_service.checks]]
-    interval = '15m0s'
-    timeout = '5s'
-    grace_period = '10s'
-    method = 'get'
-    path = '/api/healthz'
-
+  
 [processes]
   app = "./start.sh"
   


### PR DESCRIPTION
Eliminate the health check configuration from the fly.toml file to streamline the setup.