### PR TITLE
Update health check grace period and migration command

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -26,7 +26,7 @@ primary_region = 'yyz'
   [[http_service.checks]]
     interval = '1m0s'
     timeout = '5s'
-    grace_period = '10s'
+    grace_period = '30s'
     method = 'get'
     path = '/api/healthz'
 

--- a/start.sh
+++ b/start.sh
@@ -5,7 +5,7 @@ echo "🚀 Starting SheppakaiBudget..."
 
 # Run database migrations
 echo "📦 Running database migrations..."
-npx drizzle-kit migrate
+./node_modules/.bin/drizzle-kit migrate
 
 # Start the SvelteKit app
 echo "🚀 Starting SvelteKit server..."


### PR DESCRIPTION
Increase the grace period in the health check configuration to improve reliability and adjust the migration command in the start script for consistency.