### PR TITLE
Refactor migration process to use standalone runner

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -8,7 +8,8 @@
 		"*.config.ts",
 		"src/env.ts",
 		"src/instrumentation.server.ts",
-		"src/lib/hooks/is-mobile.svelte.ts"
+		"src/lib/hooks/is-mobile.svelte.ts",
+		"scripts/migrate.js"
 	],
 	"ignoreDependencies": [
 		"@flydotio/dockerfile",

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,10 @@ COPY --from=build /app/build /app/build
 COPY --from=build /app/node_modules /app/node_modules
 COPY --from=build /app/package.json /app
 
-# Copy Drizzle config and migrations for drizzle-kit CLI
-COPY --from=build /app/drizzle.config.ts /app/drizzle.config.ts
+# Copy migrations and the standalone migration runner (uses drizzle-orm, not the
+# drizzle-kit CLI, so drizzle-kit stays a devDependency and is pruned above)
 COPY --from=build /app/src/lib/server/db/migrations /app/src/lib/server/db/migrations
+COPY --from=build /app/scripts/migrate.js /app/scripts/migrate.js
 
 # Setup sqlite3 on a separate volume
 RUN mkdir -p /data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "sheppakai-budget",
-	"version": "0.0.2",
+	"version": "0.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "sheppakai-budget",
-			"version": "0.0.2",
+			"version": "0.0.1",
 			"dependencies": {
 				"@sentry/sveltekit": "^10.47.0",
 				"better-auth": "^1.6.23",
@@ -14,7 +14,6 @@
 				"canvas-confetti": "^1.9.4",
 				"d3-scale": "^4.0.2",
 				"d3-shape": "^3.2.0",
-				"drizzle-kit": "^0.31.9",
 				"drizzle-orm": "^0.45.1",
 				"mode-watcher": "^1.1.0",
 				"resend": "^6.10.0"
@@ -37,6 +36,7 @@
 				"@vitest/coverage-v8": "^4.0.18",
 				"bits-ui": "^2.18.1",
 				"clsx": "^2.1.1",
+				"drizzle-kit": "^0.31.9",
 				"fallow": "^2.99.0",
 				"globals": "^17.1.0",
 				"knip": "^6.11.0",
@@ -521,6 +521,7 @@
 			"version": "0.10.2",
 			"resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
 			"integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
+			"devOptional": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@emnapi/core": {
@@ -559,6 +560,7 @@
 			"resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
 			"integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
 			"deprecated": "Merged into tsx: https://tsx.is",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "~0.18.20",
@@ -921,6 +923,7 @@
 			"version": "0.18.20",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
 			"integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -959,6 +962,7 @@
 			"resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
 			"integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
 			"deprecated": "Merged into tsx: https://tsx.is",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@esbuild-kit/core-utils": "^3.3.2",
@@ -6177,6 +6181,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/camelcase": {
@@ -7003,6 +7008,7 @@
 			"version": "0.31.10",
 			"resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
 			"integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@drizzle-team/brocli": "^0.10.2",
@@ -7434,6 +7440,7 @@
 			"version": "0.25.12",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
 			"integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -7693,6 +7700,7 @@
 			"version": "0.28.1",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
 			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -8045,6 +8053,7 @@
 			"version": "4.14.0",
 			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
 			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"resolve-pkg-maps": "^1.0.0"
@@ -10113,6 +10122,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
 			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10504,6 +10514,7 @@
 			"version": "0.5.21",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer-from": "^1.0.0",
@@ -11073,6 +11084,7 @@
 			"version": "4.22.4",
 			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
 			"integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "~0.28.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sheppakai-budget",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"private": true,
 	"type": "module",
 	"scripts": {
@@ -37,7 +37,6 @@
 		"canvas-confetti": "^1.9.4",
 		"d3-scale": "^4.0.2",
 		"d3-shape": "^3.2.0",
-		"drizzle-kit": "^0.31.9",
 		"drizzle-orm": "^0.45.1",
 		"mode-watcher": "^1.1.0",
 		"resend": "^6.10.0"
@@ -60,6 +59,7 @@
 		"@vitest/coverage-v8": "^4.0.18",
 		"bits-ui": "^2.18.1",
 		"clsx": "^2.1.1",
+		"drizzle-kit": "^0.31.9",
 		"fallow": "^2.99.0",
 		"globals": "^17.1.0",
 		"knip": "^6.11.0",

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,32 @@
+// Standalone migration runner used at container boot (see start.sh).
+//
+// Uses drizzle-orm's migrator (a runtime dependency) instead of the drizzle-kit
+// CLI, so drizzle-kit can stay a devDependency and be pruned from the production
+// image. drizzle-orm's migrator reads the same meta/_journal.json and tracks
+// applied migrations in the same __drizzle_migrations table that drizzle-kit
+// writes, so previously-applied migrations are not re-run.
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+
+const { DATABASE_URL } = process.env;
+if (!DATABASE_URL) throw new Error('DATABASE_URL is not set');
+
+// Extract file path from DATABASE_URL (remove 'file://' prefix if present),
+// matching the parsing in src/lib/server/db/index.ts.
+const dbPath = DATABASE_URL.replace(/^file:\/\//, '');
+const migrationsFolder = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	'../src/lib/server/db/migrations'
+);
+
+console.log(`Applying migrations to ${dbPath} from ${migrationsFolder}`);
+
+const connection = new Database(dbPath);
+migrate(drizzle(connection), { migrationsFolder });
+connection.close();
+
+console.log('Migrations applied successfully');

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -5,6 +5,7 @@
 // image. drizzle-orm's migrator reads the same meta/_journal.json and tracks
 // applied migrations in the same __drizzle_migrations table that drizzle-kit
 // writes, so previously-applied migrations are not re-run.
+import { mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -18,6 +19,10 @@ if (!DATABASE_URL) throw new Error('DATABASE_URL is not set');
 // Extract file path from DATABASE_URL (remove 'file://' prefix if present),
 // matching the parsing in src/lib/server/db/index.ts.
 const dbPath = DATABASE_URL.replace(/^file:\/\//, '');
+
+const dir = dirname(dbPath);
+mkdirSync(dir, { recursive: true });
+
 const migrationsFolder = resolve(
 	dirname(fileURLToPath(import.meta.url)),
 	'../src/lib/server/db/migrations'
@@ -26,7 +31,10 @@ const migrationsFolder = resolve(
 console.log(`Applying migrations to ${dbPath} from ${migrationsFolder}`);
 
 const connection = new Database(dbPath);
-migrate(drizzle(connection), { migrationsFolder });
-connection.close();
+try {
+	migrate(drizzle(connection), { migrationsFolder });
+} finally {
+	connection.close();
+}
 
 console.log('Migrations applied successfully');

--- a/start.sh
+++ b/start.sh
@@ -5,7 +5,7 @@ echo "🚀 Starting SheppakaiBudget..."
 
 # Run database migrations
 echo "📦 Running database migrations..."
-./node_modules/.bin/drizzle-kit migrate
+node ./scripts/migrate.js
 
 # Start the SvelteKit app
 echo "🚀 Starting SvelteKit server..."


### PR DESCRIPTION
Replace the drizzle-kit CLI with a standalone migration runner that utilizes drizzle-orm. Update the Dockerfile and scripts to reflect this change, ensuring drizzle-kit remains a development dependency.