### PR TITLE
fix(auth): add shadcn spinner feedback on auth form submits

### DIFF
--- a/src/lib/components/ui/spinner/index.ts
+++ b/src/lib/components/ui/spinner/index.ts
@@ -1,0 +1,1 @@
+export { default as Spinner } from "./spinner.svelte";

--- a/src/lib/components/ui/spinner/spinner.svelte
+++ b/src/lib/components/ui/spinner/spinner.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import type { SVGAttributes } from "svelte/elements";
+
+	let {
+		class: className,
+		role = "status",
+		// we add name, color, and stroke for compatibility with different icon libraries props
+		name,
+		color,
+		stroke,
+		"aria-label": ariaLabel = "Loading",
+		...restProps
+	}: SVGAttributes<SVGSVGElement> = $props();
+</script>
+
+<Loader2Icon {role} name={name === null ? undefined : name} color={color === null ? undefined : color} stroke={stroke === null ? undefined : stroke} aria-label={ariaLabel} class={cn("size-4 animate-spin", className)} {...restProps} />

--- a/src/routes/auth/forgot-password/+page.svelte
+++ b/src/routes/auth/forgot-password/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
+	import { Spinner } from '$lib/components/ui/spinner';
 	import { superForm } from 'sveltekit-superforms';
 
 	import type { PageData } from './$types';
@@ -8,7 +9,7 @@
 	let { data }: { data: PageData } = $props();
 
 	// svelte-ignore state_referenced_locally
-	const { form, errors, message, submitting } = superForm(data.form, {
+	const { form, errors, message, submitting, enhance } = superForm(data.form, {
 		onUpdated: ({ form }) => {
 			if (form.message) {
 				// The error message will be displayed below
@@ -26,7 +27,7 @@
 			<p class="mt-2">Enter your email to receive a password reset link</p>
 		</div>
 
-		<form method="POST" class="space-y-4">
+		<form method="POST" class="space-y-4" use:enhance>
 			{#if $message}
 				<div
 					class="rounded-md p-4 {$message.includes('successful')
@@ -55,8 +56,13 @@
 				/>
 			</div>
 
-			<Button type="submit" class="w-full" disabled={$submitting}>
-				{$submitting ? 'Sending...' : 'Send Reset Link'}
+			<Button type="submit" class="w-full" disabled={$submitting} aria-busy={$submitting}>
+				{#if $submitting}
+					<Spinner class="mr-2" aria-hidden="true" />
+					Sending...
+				{:else}
+					Send Reset Link
+				{/if}
 			</Button>
 		</form>
 

--- a/src/routes/auth/register/+page.svelte
+++ b/src/routes/auth/register/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
+	import { Spinner } from '$lib/components/ui/spinner';
 	import { superForm } from 'sveltekit-superforms';
 
 	import type { PageData } from './$types';
@@ -8,7 +9,7 @@
 	let { data }: { data: PageData } = $props();
 
 	// svelte-ignore state_referenced_locally
-	const { form, errors, message, submitting } = superForm(data.form, {
+	const { form, errors, message, submitting, enhance } = superForm(data.form, {
 		onUpdated: ({ form }) => {
 			if (form.message) {
 				// The error message will be displayed below
@@ -26,7 +27,7 @@
 			<p class="mt-2">Create your account to get started</p>
 		</div>
 
-		<form method="POST" class="space-y-4">
+		<form method="POST" class="space-y-4" use:enhance>
 			{#if $message}
 				<div
 					class="rounded-md p-4 {$message.includes('successful')
@@ -105,8 +106,13 @@
 				{/if}
 			</div>
 
-			<Button type="submit" class="w-full" disabled={$submitting}>
-				{$submitting ? 'Creating Account...' : 'Register'}
+			<Button type="submit" class="w-full" disabled={$submitting} aria-busy={$submitting}>
+				{#if $submitting}
+					<Spinner class="mr-2" aria-hidden="true" />
+					Creating Account...
+				{:else}
+					Register
+				{/if}
 			</Button>
 		</form>
 

--- a/src/routes/auth/reset-password/+page.svelte
+++ b/src/routes/auth/reset-password/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
+	import { Spinner } from '$lib/components/ui/spinner';
 	import { superForm } from 'sveltekit-superforms';
 
 	import type { PageData } from './$types';
@@ -8,7 +9,7 @@
 	let { data }: { data: PageData } = $props();
 
 	// svelte-ignore state_referenced_locally
-	const { form, errors, message, submitting } = superForm(data.form, {
+	const { form, errors, message, submitting, enhance } = superForm(data.form, {
 		onUpdated: ({ form }) => {
 			if (form.message) {
 				// The error message will be displayed below
@@ -26,7 +27,7 @@
 			<p class="mt-2">Enter your new password</p>
 		</div>
 
-		<form method="POST" class="space-y-4">
+		<form method="POST" class="space-y-4" use:enhance>
 			{#if $message}
 				<div
 					class="rounded-md p-4 {$message.includes('successful')
@@ -77,8 +78,13 @@
 				{/if}
 			</div>
 
-			<Button type="submit" class="w-full" disabled={$submitting}>
-				{$submitting ? 'Resetting...' : 'Reset Password'}
+			<Button type="submit" class="w-full" disabled={$submitting} aria-busy={$submitting}>
+				{#if $submitting}
+					<Spinner class="mr-2" aria-hidden="true" />
+					Resetting...
+				{:else}
+					Reset Password
+				{/if}
 			</Button>
 		</form>
 

--- a/src/routes/auth/sign-in/+page.svelte
+++ b/src/routes/auth/sign-in/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
+	import { Spinner } from '$lib/components/ui/spinner';
 	import { superForm } from 'sveltekit-superforms';
 
 	import type { PageData } from './$types';
@@ -8,7 +9,7 @@
 	let { data }: { data: PageData } = $props();
 
 	// svelte-ignore state_referenced_locally
-	const { form, errors, message, submitting } = superForm(data.form, {
+	const { form, errors, message, submitting, enhance } = superForm(data.form, {
 		onUpdated: ({ form }) => {
 			if (form.message) {
 				// The error message will be displayed below
@@ -26,7 +27,7 @@
 			<p class="mt-2">Enter your credentials to access your account</p>
 		</div>
 
-		<form method="POST" class="space-y-4">
+		<form method="POST" class="space-y-4" use:enhance>
 			{#if $message}
 				<div
 					class="rounded-md p-4 {$message.includes('successful')
@@ -75,8 +76,13 @@
 				{/if}
 			</div>
 
-			<Button type="submit" class="w-full" disabled={$submitting}>
-				{$submitting ? 'Signing In...' : 'Sign In'}
+			<Button type="submit" class="w-full" disabled={$submitting} aria-busy={$submitting}>
+				{#if $submitting}
+					<Spinner class="mr-2" aria-hidden="true" />
+					Signing In...
+				{:else}
+					Sign In
+				{/if}
 			</Button>
 		</form>
 

--- a/src/routes/auth/sign-out/+page.svelte
+++ b/src/routes/auth/sign-out/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import { Button } from '$lib/components/ui/button';
+	import { Spinner } from '$lib/components/ui/spinner';
+
+	let isSubmitting = $state(false);
 </script>
 
 <div class="flex min-h-screen items-center justify-center bg-gray-100">
@@ -10,8 +13,25 @@
 			<p class="mt-2 text-gray-600">Are you sure you want to sign out?</p>
 		</div>
 
-		<form method="POST" use:enhance>
-			<Button type="submit" class="w-full">Sign Out</Button>
+		<form
+			method="POST"
+			use:enhance={() => {
+				isSubmitting = true;
+
+				return async ({ update }) => {
+					await update();
+					isSubmitting = false;
+				};
+			}}
+		>
+			<Button type="submit" class="w-full" disabled={isSubmitting} aria-busy={isSubmitting}>
+				{#if isSubmitting}
+					<Spinner class="mr-2" aria-hidden="true" />
+					Signing Out...
+				{:else}
+					Sign Out
+				{/if}
+			</Button>
 		</form>
 
 		<div class="text-center">


### PR DESCRIPTION
## Summary
- adds loading spinner feedback to all auth submit buttons using the shared shadcn-svelte Spinner component
- updates auth pages to show pending state consistently during form submissions
- includes the new spinner UI component files under src/lib/components/ui/spinner

## Changes
- switched auth submit button loading UI to `Spinner` from `src/lib/components/ui/spinner`
- kept disabled and `aria-busy` behavior while submitting
- ensured sign-out also shows loading feedback during submission

## Updated files
- src/routes/auth/sign-in/+page.svelte
- src/routes/auth/register/+page.svelte
- src/routes/auth/forgot-password/+page.svelte
- src/routes/auth/reset-password/+page.svelte
- src/routes/auth/sign-out/+page.svelte
- src/lib/components/ui/spinner/index.ts
- src/lib/components/ui/spinner/spinner.svelte

## Validation
- `npm run check` passed
- pre-commit hooks passed (`fmt`, `lint`, `svelte-check`)
- pre-push tests passed (Vitest suite)

Closes #261.