### PR TITLE
Harden cron auth to fail closed on invalid CRON_SECRET

### DIFF
--- a/src/lib/server/cron-auth.test.ts
+++ b/src/lib/server/cron-auth.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { verifyCronAuthorization } from './cron-auth';
+
+const strongSecret = 'a_very_strong_cron_secret_value_123';
+
+describe('verifyCronAuthorization', () => {
+	it('fails closed when secret is missing', () => {
+		const result = verifyCronAuthorization(`Bearer ${strongSecret}`, undefined);
+		expect(result).toEqual({ authorized: false, reason: 'missing_secret' });
+	});
+
+	it('fails closed when secret is blank', () => {
+		const result = verifyCronAuthorization('Bearer token', '   ');
+		expect(result).toEqual({ authorized: false, reason: 'blank_secret' });
+	});
+
+	it('fails closed when secret is too weak', () => {
+		const result = verifyCronAuthorization('Bearer token', 'short-secret');
+		expect(result).toEqual({ authorized: false, reason: 'weak_secret' });
+	});
+
+	it('rejects missing authorization header', () => {
+		const result = verifyCronAuthorization(null, strongSecret);
+		expect(result).toEqual({ authorized: false, reason: 'missing_header' });
+	});
+
+	it('rejects malformed authorization header', () => {
+		expect(verifyCronAuthorization('Bearer', strongSecret)).toEqual({
+			authorized: false,
+			reason: 'malformed_header'
+		});
+		expect(verifyCronAuthorization('Bearer token extra', strongSecret)).toEqual({
+			authorized: false,
+			reason: 'malformed_header'
+		});
+		expect(verifyCronAuthorization('Bearer ', strongSecret)).toEqual({
+			authorized: false,
+			reason: 'malformed_header'
+		});
+	});
+
+	it('rejects non-bearer auth schemes', () => {
+		const result = verifyCronAuthorization('Basic token', strongSecret);
+		expect(result).toEqual({ authorized: false, reason: 'invalid_scheme' });
+	});
+
+	it('rejects token mismatch', () => {
+		const result = verifyCronAuthorization('Bearer wrong-token', strongSecret);
+		expect(result).toEqual({ authorized: false, reason: 'token_mismatch' });
+	});
+
+	it('authorizes valid bearer token with strong secret', () => {
+		const result = verifyCronAuthorization(`Bearer ${strongSecret}`, strongSecret);
+		expect(result).toEqual({ authorized: true });
+	});
+});

--- a/src/lib/server/cron-auth.ts
+++ b/src/lib/server/cron-auth.ts
@@ -1,0 +1,84 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+const MIN_CRON_SECRET_LENGTH = 32;
+
+type CronAuthFailureReason =
+	| 'missing_secret'
+	| 'blank_secret'
+	| 'weak_secret'
+	| 'missing_header'
+	| 'invalid_scheme'
+	| 'malformed_header'
+	| 'token_mismatch';
+
+type CronAuthResult = { authorized: true } | { authorized: false; reason: CronAuthFailureReason };
+
+function validateCronSecret(
+	secret: string | undefined
+): { authorized: true; secret: string } | { authorized: false; reason: CronAuthFailureReason } {
+	if (secret === undefined) {
+		return { authorized: false, reason: 'missing_secret' };
+	}
+
+	if (secret.trim().length === 0) {
+		return { authorized: false, reason: 'blank_secret' };
+	}
+
+	if (secret.length < MIN_CRON_SECRET_LENGTH) {
+		return { authorized: false, reason: 'weak_secret' };
+	}
+
+	return { authorized: true, secret };
+}
+
+function parseBearerToken(header: string | null): {
+	token?: string;
+	reason?: CronAuthFailureReason;
+} {
+	if (header === null) {
+		return { reason: 'missing_header' };
+	}
+
+	const parts = header.split(' ');
+	if (parts.length !== 2) {
+		return { reason: 'malformed_header' };
+	}
+
+	if (parts[0] !== 'Bearer') {
+		return { reason: 'invalid_scheme' };
+	}
+
+	const token = parts[1];
+	if (token.length === 0) {
+		return { reason: 'malformed_header' };
+	}
+
+	return { token };
+}
+
+function constantTimeTokenMatch(providedToken: string, expectedToken: string): boolean {
+	const providedHash = createHash('sha256').update(providedToken).digest();
+	const expectedHash = createHash('sha256').update(expectedToken).digest();
+	return timingSafeEqual(providedHash, expectedHash);
+}
+
+export function verifyCronAuthorization(
+	header: string | null,
+	configuredSecret: string | undefined
+): CronAuthResult {
+	const secretValidation = validateCronSecret(configuredSecret);
+	if (!secretValidation.authorized) {
+		return secretValidation;
+	}
+
+	const parsedHeader = parseBearerToken(header);
+	if (!parsedHeader.token) {
+		return { authorized: false, reason: parsedHeader.reason ?? 'malformed_header' };
+	}
+
+	if (!constantTimeTokenMatch(parsedHeader.token, secretValidation.secret)) {
+		return { authorized: false, reason: 'token_mismatch' };
+	}
+
+	return { authorized: true };
+}

--- a/src/routes/api/cron/email-weekly-summary/+server.ts
+++ b/src/routes/api/cron/email-weekly-summary/+server.ts
@@ -1,15 +1,14 @@
 import { CRON_SECRET } from '$app/env/private';
+import { verifyCronAuthorization } from '$lib/server/cron-auth';
 import { runWeeklySummaryEmail } from '$lib/server/jobs/weeklySummaryEmail';
 import { logger } from '$lib/server/logger';
-import { type RequestHandler } from '@sveltejs/kit';
-import { json } from '@sveltejs/kit';
+import { json, type RequestHandler } from '@sveltejs/kit';
 
 export const POST: RequestHandler = async ({ request }) => {
-	const authHeader = request.headers.get('authorization');
-	const expectedToken = CRON_SECRET;
+	const authResult = verifyCronAuthorization(request.headers.get('authorization'), CRON_SECRET);
 
-	if (!authHeader || authHeader !== `Bearer ${expectedToken}`) {
-		logger.warn('⚠️ Unauthorized cron job attempt');
+	if (!authResult.authorized) {
+		logger.warn('⚠️ Unauthorized cron job attempt', { reason: authResult.reason });
 		return json({ error: 'Unauthorized' }, { status: 401 });
 	}
 

--- a/src/routes/api/cron/reset-recurring-paid/+server.ts
+++ b/src/routes/api/cron/reset-recurring-paid/+server.ts
@@ -1,15 +1,14 @@
 import { CRON_SECRET } from '$app/env/private';
+import { verifyCronAuthorization } from '$lib/server/cron-auth';
 import { runResetRecurringPaid } from '$lib/server/jobs/recurring';
 import { logger } from '$lib/server/logger';
-import { type RequestHandler } from '@sveltejs/kit';
-import { json } from '@sveltejs/kit';
+import { json, type RequestHandler } from '@sveltejs/kit';
 
 export const POST: RequestHandler = async ({ request }) => {
-	const authHeader = request.headers.get('authorization');
-	const expectedToken = CRON_SECRET;
+	const authResult = verifyCronAuthorization(request.headers.get('authorization'), CRON_SECRET);
 
-	if (!authHeader || authHeader !== `Bearer ${expectedToken}`) {
-		logger.warn('⚠️ Unauthorized cron job attempt');
+	if (!authResult.authorized) {
+		logger.warn('⚠️ Unauthorized cron job attempt', { reason: authResult.reason });
 		return json({ error: 'Unauthorized' }, { status: 401 });
 	}
 


### PR DESCRIPTION
## Summary
- add a shared cron auth verifier for server endpoints
- fail closed when `CRON_SECRET` is missing, blank, or shorter than 32 chars
- require strict `Authorization: Bearer <token>` formatting and reject malformed headers
- compare cron tokens with constant-time hash comparison to avoid timing leaks
- wire both cron endpoints to use the shared verifier and log explicit failure reasons
- add regression tests covering missing/blank/weak secrets and malformed headers

## Verification
- npm run check
- npm run lint
- npm test
- npm run build

Closes #275