### PR TITLE
Unify duplicated auth server action flow

### DIFF
--- a/src/lib/server/actions/auth-form-handler.test.ts
+++ b/src/lib/server/actions/auth-form-handler.test.ts
@@ -1,0 +1,59 @@
+import { redirect } from '@sveltejs/kit';
+import { superValidate } from 'sveltekit-superforms';
+import { zod4 } from 'sveltekit-superforms/adapters';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { handleAuthFormAction } from './auth-form-handler';
+
+const testSchema = z.object({
+	email: z.string().email()
+});
+
+describe('handleAuthFormAction', () => {
+	it('rethrows redirect errors without converting them to form failures', async () => {
+		const form = await superValidate(zod4(testSchema));
+
+		await expect(
+			handleAuthFormAction(
+				form,
+				async () => {
+					throw redirect(302, '/dashboard');
+				},
+				{
+					loggerContext: 'test',
+					fallbackMessage: 'fallback',
+					buildErrorPayload: (errorMessage) => errorMessage
+				}
+			)
+		).rejects.toMatchObject({
+			status: 302,
+			location: '/dashboard'
+		});
+	});
+
+	it('returns a form failure payload for auth errors', async () => {
+		const form = await superValidate(zod4(testSchema));
+		const result = await handleAuthFormAction(
+			form,
+			async () => {
+				throw new Error('boom');
+			},
+			{
+				loggerContext: 'test',
+				fallbackMessage: 'fallback',
+				buildErrorPayload: (errorMessage) => ({ type: 'error', text: errorMessage })
+			}
+		);
+
+		expect(result).toMatchObject({
+			status: 400,
+			data: {
+				form: expect.objectContaining({
+					valid: false,
+					message: { type: 'error', text: 'fallback' }
+				})
+			}
+		});
+	});
+});

--- a/src/lib/server/actions/auth-form-handler.ts
+++ b/src/lib/server/actions/auth-form-handler.ts
@@ -1,0 +1,35 @@
+import { logger } from '$lib/server/logger';
+import { getBetterAuthErrorMessage } from '$lib/utils';
+import { isRedirect } from '@sveltejs/kit';
+import { message } from 'sveltekit-superforms';
+import type { SuperValidated } from 'sveltekit-superforms';
+
+type MessageOptions = NonNullable<Parameters<typeof message>[2]>;
+
+interface AuthFormActionOptions {
+	loggerContext: string;
+	fallbackMessage: string;
+	buildErrorPayload: (errorMessage: string) => Parameters<typeof message>[1];
+	status?: MessageOptions['status'];
+}
+
+export async function handleAuthFormAction<TForm extends Record<string, unknown>>(
+	form: SuperValidated<TForm>,
+	action: () => Promise<unknown>,
+	options: AuthFormActionOptions
+): Promise<unknown> {
+	try {
+		return await action();
+	} catch (error) {
+		if (isRedirect(error)) {
+			throw error;
+		}
+
+		logger.error(options.loggerContext, error);
+		const errorMessage = getBetterAuthErrorMessage(error, options.fallbackMessage);
+
+		return message(form, options.buildErrorPayload(errorMessage), {
+			status: (options.status ?? 400) as MessageOptions['status']
+		});
+	}
+}

--- a/src/routes/auth/forgot-password/+page.server.ts
+++ b/src/routes/auth/forgot-password/+page.server.ts
@@ -1,8 +1,7 @@
 import { BETTER_AUTH_BASE_URL } from '$app/env/private';
+import { handleAuthFormAction } from '$lib/server/actions/auth-form-handler';
 import { auth } from '$lib/server/auth';
-import { logger } from '$lib/server/logger';
-import { getBetterAuthErrorMessage } from '$lib/utils';
-import { fail, isRedirect, redirect } from '@sveltejs/kit';
+import { fail, redirect } from '@sveltejs/kit';
 import { message, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 import { z } from 'zod';
@@ -42,36 +41,30 @@ export const actions: Actions = {
 			});
 		}
 
-		try {
-			const redirectTo = `${BETTER_AUTH_BASE_URL}/auth/reset-password`;
+		return handleAuthFormAction(
+			form,
+			async () => {
+				const redirectTo = `${BETTER_AUTH_BASE_URL}/auth/reset-password`;
 
-			await auth.api.requestPasswordReset({
-				body: {
-					email: form.data.email,
-					redirectTo
-				}
-			});
+				await auth.api.requestPasswordReset({
+					body: {
+						email: form.data.email,
+						redirectTo
+					}
+				});
 
-			// Don't reveal if the email exists or not for security reasons
-			return message(
-				form,
-				'If an account exists with that email, you will receive a password reset link.'
-			);
-		} catch (error) {
-			// Don't catch redirects as errors - re-throw them
-			if (isRedirect(error)) {
-				throw error;
+				// Don't reveal if the email exists or not for security reasons
+				return message(
+					form,
+					'If an account exists with that email, you will receive a password reset link.'
+				);
+			},
+			{
+				loggerContext: 'Password reset request failed',
+				fallbackMessage:
+					'If an account exists with that email, you will receive a password reset link.',
+				buildErrorPayload: (errorMessage) => errorMessage
 			}
-
-			logger.error('Password reset request failed', error);
-			// Get user-friendly error message from better-auth error
-			// Don't reveal if the email exists or not for security reasons
-			const errorMessage = getBetterAuthErrorMessage(
-				error,
-				'If an account exists with that email, you will receive a password reset link.'
-			);
-
-			return message(form, errorMessage);
-		}
+		);
 	}
 } satisfies Actions;

--- a/src/routes/auth/register/+page.server.ts
+++ b/src/routes/auth/register/+page.server.ts
@@ -1,8 +1,7 @@
 import { registerSchema } from '$lib/formSchemas';
+import { handleAuthFormAction } from '$lib/server/actions/auth-form-handler';
 import { auth } from '$lib/server/auth';
-import { logger } from '$lib/server/logger';
-import { getBetterAuthErrorMessage } from '$lib/utils';
-import { isRedirect, redirect } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import { message, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 
@@ -38,32 +37,27 @@ export const actions: Actions = {
 			);
 		}
 
-		try {
-			await auth.api.signUpEmail({
-				body: {
-					email: form.data.email,
-					password: form.data.password,
-					name: form.data.name
-				},
-				headers: request.headers
-			});
+		return handleAuthFormAction(
+			form,
+			async () => {
+				await auth.api.signUpEmail({
+					body: {
+						email: form.data.email,
+						password: form.data.password,
+						name: form.data.name
+					},
+					headers: request.headers
+				});
 
-			// Redirect to verify-email page with user's email
-			throw redirect(302, `/auth/verify-email?email=${encodeURIComponent(form.data.email)}`);
-		} catch (error) {
-			// Don't catch redirects as errors - re-throw them
-			if (isRedirect(error)) {
-				throw error;
+				// Redirect to verify-email page with user's email
+				throw redirect(302, `/auth/verify-email?email=${encodeURIComponent(form.data.email)}`);
+			},
+			{
+				loggerContext: 'Registration failed',
+				fallbackMessage: 'Registration failed. Please try again.',
+				buildErrorPayload: (errorMessage) => ({ type: 'error', text: errorMessage }),
+				status: 400
 			}
-
-			logger.error('Registration failed', error);
-			// Get user-friendly error message from better-auth error
-			const errorMessage = getBetterAuthErrorMessage(
-				error,
-				'Registration failed. Please try again.'
-			);
-
-			return message(form, { type: 'error', text: errorMessage }, { status: 400 });
-		}
+		);
 	}
 } satisfies Actions;

--- a/src/routes/auth/reset-password/+page.server.ts
+++ b/src/routes/auth/reset-password/+page.server.ts
@@ -1,7 +1,6 @@
+import { handleAuthFormAction } from '$lib/server/actions/auth-form-handler';
 import { auth } from '$lib/server/auth';
-import { logger } from '$lib/server/logger';
-import { getBetterAuthErrorMessage } from '$lib/utils';
-import { isRedirect, redirect } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import { message, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 import { z } from 'zod';
@@ -61,29 +60,24 @@ export const actions: Actions = {
 			);
 		}
 
-		try {
-			await auth.api.resetPassword({
-				body: {
-					token: form.data.token,
-					newPassword: form.data.password
-				}
-			});
+		return handleAuthFormAction(
+			form,
+			async () => {
+				await auth.api.resetPassword({
+					body: {
+						token: form.data.token,
+						newPassword: form.data.password
+					}
+				});
 
-			throw redirect(302, '/auth/sign-in?message=Password reset successful! Please sign in.');
-		} catch (error) {
-			// Don't catch redirects as errors - re-throw them
-			if (isRedirect(error)) {
-				throw error;
+				throw redirect(302, '/auth/sign-in?message=Password reset successful! Please sign in.');
+			},
+			{
+				loggerContext: 'Password reset failed',
+				fallbackMessage: 'Failed to reset password. Please try again.',
+				buildErrorPayload: (errorMessage) => ({ type: 'error', text: errorMessage }),
+				status: 400
 			}
-
-			logger.error('Password reset failed', error);
-			// Get user-friendly error message from better-auth error
-			const errorMessage = getBetterAuthErrorMessage(
-				error,
-				'Failed to reset password. Please try again.'
-			);
-
-			return message(form, { type: 'error', text: errorMessage }, { status: 400 });
-		}
+		);
 	}
 } satisfies Actions;

--- a/src/routes/auth/sign-in/+page.server.ts
+++ b/src/routes/auth/sign-in/+page.server.ts
@@ -1,8 +1,7 @@
 import { signInSchema } from '$lib/formSchemas';
+import { handleAuthFormAction } from '$lib/server/actions/auth-form-handler';
 import { auth } from '$lib/server/auth';
-import { logger } from '$lib/server/logger';
-import { getBetterAuthErrorMessage } from '$lib/utils';
-import { isRedirect, redirect } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import { message, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 
@@ -35,30 +34,24 @@ export const actions: Actions = {
 			return message(form, 'Please correct the errors in the form.', { status: 400 });
 		}
 
-		try {
-			await auth.api.signInEmail({
-				body: {
-					email: form.data.email,
-					password: form.data.password
-				},
-				headers: request.headers
-			});
+		return handleAuthFormAction(
+			form,
+			async () => {
+				await auth.api.signInEmail({
+					body: {
+						email: form.data.email,
+						password: form.data.password
+					},
+					headers: request.headers
+				});
 
-			throw redirect(302, '/dashboard');
-		} catch (error) {
-			// Don't catch redirects as errors - re-throw them
-			if (isRedirect(error)) {
-				throw error;
+				throw redirect(302, '/dashboard');
+			},
+			{
+				loggerContext: 'Sign-in failed',
+				fallbackMessage: 'An error occurred during sign-in. Please try again.',
+				buildErrorPayload: (errorMessage) => errorMessage
 			}
-
-			logger.error('Sign-in failed', error);
-			// Get user-friendly error message from better-auth error
-			const errorMessage = getBetterAuthErrorMessage(
-				error,
-				'An error occurred during sign-in. Please try again.'
-			);
-
-			return message(form, errorMessage, { status: 400 });
-		}
+		);
 	}
 } satisfies Actions;


### PR DESCRIPTION
## Summary
- extracted a shared auth action helper to centralize redirect/error/message handling for the auth server actions
- updated the sign-in, register, forgot-password, and reset-password routes to use the shared helper without changing their current redirects or user-facing messages
- added focused tests for the new helper

## Testing
- npm run check
- npm test

Fixes #278