### PR TITLE
Consolidate duplicated auth page layout/message UI

### DIFF
--- a/src/lib/components/AuthCardLayout.svelte
+++ b/src/lib/components/AuthCardLayout.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		title: string;
+		description: string;
+		children: Snippet;
+		footer?: Snippet;
+	}
+
+	let { title, description, children, footer }: Props = $props();
+</script>
+
+<div class="flex min-h-screen items-center justify-center">
+	<div
+		class="mx-4 w-full max-w-md space-y-6 rounded-xl border border-white/20 bg-white/10 p-8 shadow-2xl backdrop-blur-md"
+	>
+		<div class="text-center">
+			<h1 class="text-3xl font-bold">{title}</h1>
+			<p class="mt-2">{description}</p>
+		</div>
+
+		{@render children()}
+
+		{#if footer}
+			<div class="space-y-2 text-center">
+				{@render footer()}
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/AuthCardLayout.test.ts
+++ b/src/lib/components/AuthCardLayout.test.ts
@@ -1,0 +1,51 @@
+import { createRawSnippet } from 'svelte';
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+
+import AuthCardLayout from './AuthCardLayout.svelte';
+
+const snippet = (html: string) => createRawSnippet(() => ({ render: () => html }));
+
+describe('AuthCardLayout', () => {
+	it('renders the title, description and children', () => {
+		const html = render(AuthCardLayout, {
+			props: {
+				title: 'Sign In',
+				description: 'Enter your credentials to access your account',
+				children: snippet('<form>form body</form>')
+			}
+		}).body;
+
+		expect(html).toContain('Sign In');
+		expect(html).toContain('Enter your credentials to access your account');
+		expect(html).toContain('form body');
+		expect(html).toContain('max-w-md');
+		expect(html).toContain('backdrop-blur-md');
+	});
+
+	it('omits the footer wrapper when no footer snippet is supplied', () => {
+		const html = render(AuthCardLayout, {
+			props: {
+				title: 'Reset Password',
+				description: 'Enter your new password',
+				children: snippet('<form>form body</form>')
+			}
+		}).body;
+
+		expect(html).not.toContain('space-y-2 text-center');
+	});
+
+	it('renders the footer snippet when supplied', () => {
+		const html = render(AuthCardLayout, {
+			props: {
+				title: 'Register',
+				description: 'Create your account to get started',
+				children: snippet('<form>form body</form>'),
+				footer: snippet('<a href="/auth/sign-in">Sign in here</a>')
+			}
+		}).body;
+
+		expect(html).toContain('space-y-2 text-center');
+		expect(html).toContain('Sign in here');
+	});
+});

--- a/src/lib/components/AuthFormField.svelte
+++ b/src/lib/components/AuthFormField.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { Input } from '$lib/components/ui/input';
+	import type { HTMLInputAttributes } from 'svelte/elements';
+
+	interface Props {
+		/** Used for both the input `id` and its `name`, so it must match the form field key. */
+		id: string;
+		label: string;
+		value: string;
+		type?: 'email' | 'password' | 'text';
+		placeholder?: string;
+		autocomplete?: HTMLInputAttributes['autocomplete'];
+		required?: boolean;
+		errors?: string[];
+	}
+
+	let {
+		id,
+		label,
+		value = $bindable(),
+		type = 'text',
+		placeholder,
+		autocomplete,
+		required = false,
+		errors
+	}: Props = $props();
+</script>
+
+<div class="space-y-2">
+	<label for={id} class="block text-sm font-medium">{label}</label>
+	<Input
+		{id}
+		name={id}
+		{type}
+		{placeholder}
+		bind:value
+		class={errors ? 'border-red-400 bg-white/80' : 'bg-white/80'}
+		{autocomplete}
+		{required}
+	/>
+	{#if errors}
+		<p class="text-sm text-red-200">{errors}</p>
+	{/if}
+</div>

--- a/src/lib/components/AuthFormField.test.ts
+++ b/src/lib/components/AuthFormField.test.ts
@@ -1,0 +1,63 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+
+import AuthFormField from './AuthFormField.svelte';
+
+describe('AuthFormField', () => {
+	it('renders a labelled input wired to the given id', () => {
+		const html = render(AuthFormField, {
+			props: {
+				id: 'email',
+				label: 'Email',
+				type: 'email',
+				placeholder: 'Enter your email',
+				value: 'user@example.com',
+				autocomplete: 'email',
+				required: true
+			}
+		}).body;
+
+		expect(html).toContain('for="email"');
+		expect(html).toContain('id="email"');
+		expect(html).toContain('name="email"');
+		expect(html).toContain('type="email"');
+		expect(html).toContain('placeholder="Enter your email"');
+		expect(html).toContain('value="user@example.com"');
+		expect(html).toContain('autocomplete="email"');
+		expect(html).toContain('required');
+		expect(html).toContain('Email');
+	});
+
+	it('omits the required attribute by default', () => {
+		const html = render(AuthFormField, {
+			props: { id: 'name', label: 'Name', value: '' }
+		}).body;
+
+		expect(html).not.toContain('required');
+		expect(html).toContain('type="text"');
+	});
+
+	it('applies error styling and renders messages when errors are present', () => {
+		const html = render(AuthFormField, {
+			props: {
+				id: 'password',
+				label: 'Password',
+				type: 'password',
+				value: '',
+				errors: ['Password must be at least 12 characters']
+			}
+		}).body;
+
+		expect(html).toContain('border-red-400');
+		expect(html).toContain('Password must be at least 12 characters');
+	});
+
+	it('does not render an error paragraph when there are no errors', () => {
+		const html = render(AuthFormField, {
+			props: { id: 'password', label: 'Password', type: 'password', value: '' }
+		}).body;
+
+		expect(html).not.toContain('border-red-400');
+		expect(html).not.toContain('text-red-200');
+	});
+});

--- a/src/lib/components/AuthFormMessage.svelte
+++ b/src/lib/components/AuthFormMessage.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	interface Props {
+		message: string | undefined;
+	}
+
+	let { message }: Props = $props();
+
+	const isSuccess = $derived(message?.includes('successful') ?? false);
+</script>
+
+{#if message}
+	<div class="rounded-md p-4 {isSuccess ? 'bg-green-50/80' : 'bg-red-50/80'} backdrop-blur-sm">
+		<div class="text-sm {isSuccess ? 'text-green-700' : 'text-red-700'}">
+			{message}
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/AuthFormMessage.test.ts
+++ b/src/lib/components/AuthFormMessage.test.ts
@@ -1,0 +1,32 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+
+import AuthFormMessage from './AuthFormMessage.svelte';
+
+describe('AuthFormMessage', () => {
+	it('renders nothing when there is no message', () => {
+		const html = render(AuthFormMessage, { props: { message: undefined } }).body;
+
+		expect(html).not.toContain('<div');
+	});
+
+	it('renders success styling for messages containing "successful"', () => {
+		const html = render(AuthFormMessage, {
+			props: { message: 'Registration successful! Please sign in.' }
+		}).body;
+
+		expect(html).toContain('Registration successful! Please sign in.');
+		expect(html).toContain('bg-green-50/80');
+		expect(html).toContain('text-green-700');
+	});
+
+	it('renders error styling for any other message', () => {
+		const html = render(AuthFormMessage, {
+			props: { message: 'Invalid email or password' }
+		}).body;
+
+		expect(html).toContain('Invalid email or password');
+		expect(html).toContain('bg-red-50/80');
+		expect(html).toContain('text-red-700');
+	});
+});

--- a/src/routes/auth/forgot-password/+page.svelte
+++ b/src/routes/auth/forgot-password/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import AuthCardLayout from '$lib/components/AuthCardLayout.svelte';
+	import AuthFormField from '$lib/components/AuthFormField.svelte';
+	import AuthFormMessage from '$lib/components/AuthFormMessage.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Input } from '$lib/components/ui/input';
 	import { Spinner } from '$lib/components/ui/spinner';
 	import { superForm } from 'sveltekit-superforms';
 
@@ -9,68 +11,41 @@
 	let { data }: { data: PageData } = $props();
 
 	// svelte-ignore state_referenced_locally
-	const { form, errors, message, submitting, enhance } = superForm(data.form, {
-		onUpdated: ({ form }) => {
-			if (form.message) {
-				// The error message will be displayed below
-			}
-		}
-	});
+	const { form, errors, message, submitting, enhance } = superForm(data.form);
 </script>
 
-<div class="flex min-h-screen items-center justify-center">
-	<div
-		class="mx-4 w-full max-w-md space-y-6 rounded-xl border border-white/20 bg-white/10 p-8 shadow-2xl backdrop-blur-md"
-	>
-		<div class="text-center">
-			<h1 class="text-3xl font-bold">Forgot Password</h1>
-			<p class="mt-2">Enter your email to receive a password reset link</p>
-		</div>
+<AuthCardLayout
+	title="Forgot Password"
+	description="Enter your email to receive a password reset link"
+>
+	<form method="POST" class="space-y-4" use:enhance>
+		<AuthFormMessage message={$message} />
 
-		<form method="POST" class="space-y-4" use:enhance>
-			{#if $message}
-				<div
-					class="rounded-md p-4 {$message.includes('successful')
-						? 'bg-green-50/80'
-						: 'bg-red-50/80'} backdrop-blur-sm"
-				>
-					<div
-						class="text-sm {$message.includes('successful') ? 'text-green-700' : 'text-red-700'}"
-					>
-						{$message}
-					</div>
-				</div>
+		<AuthFormField
+			id="email"
+			label="Email"
+			type="email"
+			placeholder="Enter your email"
+			bind:value={$form.email}
+			errors={$errors.email}
+			autocomplete="email"
+			required
+		/>
+
+		<Button type="submit" class="w-full" disabled={$submitting} aria-busy={$submitting}>
+			{#if $submitting}
+				<Spinner class="mr-2" aria-hidden="true" />
+				Sending...
+			{:else}
+				Send Reset Link
 			{/if}
+		</Button>
+	</form>
 
-			<div class="space-y-2">
-				<label for="email" class="block text-sm font-medium">Email</label>
-				<Input
-					id="email"
-					name="email"
-					type="email"
-					placeholder="Enter your email"
-					bind:value={$form.email}
-					class={$errors.email ? 'border-red-400 bg-white/80' : 'bg-white/80'}
-					autocomplete="email"
-					required
-				/>
-			</div>
-
-			<Button type="submit" class="w-full" disabled={$submitting} aria-busy={$submitting}>
-				{#if $submitting}
-					<Spinner class="mr-2" aria-hidden="true" />
-					Sending...
-				{:else}
-					Send Reset Link
-				{/if}
-			</Button>
-		</form>
-
-		<div class="text-center">
-			<p class="text-sm">
-				Remember your password?
-				<a href="/auth/sign-in" class="font-medium underline"> Sign in here </a>
-			</p>
-		</div>
-	</div>
-</div>
+	{#snippet footer()}
+		<p class="text-sm">
+			Remember your password?
+			<a href="/auth/sign-in" class="font-medium underline"> Sign in here </a>
+		</p>
+	{/snippet}
+</AuthCardLayout>

--- a/src/routes/auth/register/+page.svelte
+++ b/src/routes/auth/register/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import AuthCardLayout from '$lib/components/AuthCardLayout.svelte';
+	import AuthFormField from '$lib/components/AuthFormField.svelte';
+	import AuthFormMessage from '$lib/components/AuthFormMessage.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Input } from '$lib/components/ui/input';
 	import { Spinner } from '$lib/components/ui/spinner';
 	import { superForm } from 'sveltekit-superforms';
 
@@ -9,118 +11,69 @@
 	let { data }: { data: PageData } = $props();
 
 	// svelte-ignore state_referenced_locally
-	const { form, errors, message, submitting, enhance } = superForm(data.form, {
-		onUpdated: ({ form }) => {
-			if (form.message) {
-				// The error message will be displayed below
-			}
-		}
-	});
+	const { form, errors, message, submitting, enhance } = superForm(data.form);
 </script>
 
-<div class="flex min-h-screen items-center justify-center">
-	<div
-		class="mx-4 w-full max-w-md space-y-6 rounded-xl border border-white/20 bg-white/10 p-8 shadow-2xl backdrop-blur-md"
-	>
-		<div class="text-center">
-			<h1 class="text-3xl font-bold">Register</h1>
-			<p class="mt-2">Create your account to get started</p>
-		</div>
+<AuthCardLayout title="Register" description="Create your account to get started">
+	<form method="POST" class="space-y-4" use:enhance>
+		<AuthFormMessage message={$message} />
 
-		<form method="POST" class="space-y-4" use:enhance>
-			{#if $message}
-				<div
-					class="rounded-md p-4 {$message.includes('successful')
-						? 'bg-green-50/80'
-						: 'bg-red-50/80'} backdrop-blur-sm"
-				>
-					<div
-						class="text-sm {$message.includes('successful') ? 'text-green-700' : 'text-red-700'}"
-					>
-						{$message}
-					</div>
-				</div>
+		<AuthFormField
+			id="email"
+			label="Email"
+			type="email"
+			placeholder="Enter your email"
+			bind:value={$form.email}
+			errors={$errors.email}
+			autocomplete="email"
+			required
+		/>
+
+		<AuthFormField
+			id="name"
+			label="Name"
+			placeholder="Enter your name"
+			bind:value={$form.name}
+			errors={$errors.name}
+			autocomplete="given-name"
+		/>
+
+		<AuthFormField
+			id="password"
+			label="Password"
+			type="password"
+			placeholder="Create a password"
+			bind:value={$form.password}
+			errors={$errors.password}
+			autocomplete="new-password"
+			required
+		/>
+
+		<AuthFormField
+			id="confirmPassword"
+			label="Confirm Password"
+			type="password"
+			placeholder="Confirm your password"
+			bind:value={$form.confirmPassword}
+			errors={$errors.confirmPassword}
+			autocomplete="new-password"
+			required
+		/>
+
+		<Button type="submit" class="w-full" disabled={$submitting} aria-busy={$submitting}>
+			{#if $submitting}
+				<Spinner class="mr-2" aria-hidden="true" />
+				Creating Account...
+			{:else}
+				Register
 			{/if}
+		</Button>
+	</form>
 
-			<div class="space-y-2">
-				<label for="email" class="block text-sm font-medium">Email</label>
-				<Input
-					id="email"
-					name="email"
-					type="email"
-					placeholder="Enter your email"
-					bind:value={$form.email}
-					class={$errors.email ? 'border-red-400 bg-white/80' : 'bg-white/80'}
-					autocomplete="email"
-					required
-				/>
-			</div>
-
-			<div class="space-y-2">
-				<label for="name" class="block text-sm font-medium">Name</label>
-				<Input
-					id="name"
-					name="name"
-					type="text"
-					placeholder="Enter your name"
-					bind:value={$form.name}
-					class={$errors.name ? 'border-red-400 bg-white/80' : 'bg-white/80'}
-					autocomplete="given-name"
-				/>
-				{#if $errors.name}
-					<p class="text-sm text-red-200">{$errors.name}</p>
-				{/if}
-			</div>
-
-			<div class="space-y-2">
-				<label for="password" class="block text-sm font-medium">Password</label>
-				<Input
-					id="password"
-					name="password"
-					type="password"
-					placeholder="Create a password"
-					bind:value={$form.password}
-					class={$errors.password ? 'border-red-400 bg-white/80' : 'bg-white/80'}
-					autocomplete="new-password"
-					required
-				/>
-				{#if $errors.password}
-					<p class="text-sm text-red-200">{$errors.password}</p>
-				{/if}
-			</div>
-
-			<div class="space-y-2">
-				<label for="confirmPassword" class="block text-sm font-medium">Confirm Password</label>
-				<Input
-					id="confirmPassword"
-					name="confirmPassword"
-					type="password"
-					placeholder="Confirm your password"
-					bind:value={$form.confirmPassword}
-					class={$errors.confirmPassword ? 'border-red-400 bg-white/80' : 'bg-white/80'}
-					autocomplete="new-password"
-					required
-				/>
-				{#if $errors.confirmPassword}
-					<p class="text-sm text-red-200">{$errors.confirmPassword}</p>
-				{/if}
-			</div>
-
-			<Button type="submit" class="w-full" disabled={$submitting} aria-busy={$submitting}>
-				{#if $submitting}
-					<Spinner class="mr-2" aria-hidden="true" />
-					Creating Account...
-				{:else}
-					Register
-				{/if}
-			</Button>
-		</form>
-
-		<div class="text-center">
-			<p class="text-sm">
-				Already have an account?
-				<a href="/auth/sign-in" class="font-medium underline"> Sign in here </a>
-			</p>
-		</div>
-	</div>
-</div>
+	{#snippet footer()}
+		<p class="text-sm">
+			Already have an account?
+			<a href="/auth/sign-in" class="font-medium underline"> Sign in here </a>
+		</p>
+	{/snippet}
+</AuthCardLayout>

--- a/src/routes/auth/reset-password/+page.svelte
+++ b/src/routes/auth/reset-password/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import AuthCardLayout from '$lib/components/AuthCardLayout.svelte';
+	import AuthFormField from '$lib/components/AuthFormField.svelte';
+	import AuthFormMessage from '$lib/components/AuthFormMessage.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Input } from '$lib/components/ui/input';
 	import { Spinner } from '$lib/components/ui/spinner';
 	import { superForm } from 'sveltekit-superforms';
 
@@ -9,89 +11,50 @@
 	let { data }: { data: PageData } = $props();
 
 	// svelte-ignore state_referenced_locally
-	const { form, errors, message, submitting, enhance } = superForm(data.form, {
-		onUpdated: ({ form }) => {
-			if (form.message) {
-				// The error message will be displayed below
-			}
-		}
-	});
+	const { form, errors, message, submitting, enhance } = superForm(data.form);
 </script>
 
-<div class="flex min-h-screen items-center justify-center">
-	<div
-		class="mx-4 w-full max-w-md space-y-6 rounded-xl border border-white/20 bg-white/10 p-8 shadow-2xl backdrop-blur-md"
-	>
-		<div class="text-center">
-			<h1 class="text-3xl font-bold">Reset Password</h1>
-			<p class="mt-2">Enter your new password</p>
-		</div>
+<AuthCardLayout title="Reset Password" description="Enter your new password">
+	<form method="POST" class="space-y-4" use:enhance>
+		<AuthFormMessage message={$message} />
 
-		<form method="POST" class="space-y-4" use:enhance>
-			{#if $message}
-				<div
-					class="rounded-md p-4 {$message.includes('successful')
-						? 'bg-green-50/80'
-						: 'bg-red-50/80'} backdrop-blur-sm"
-				>
-					<div
-						class="text-sm {$message.includes('successful') ? 'text-green-700' : 'text-red-700'}"
-					>
-						{$message}
-					</div>
-				</div>
+		<input type="hidden" name="token" bind:value={data.token} />
+
+		<AuthFormField
+			id="password"
+			label="New Password"
+			type="password"
+			placeholder="Enter new password (min 8 characters)"
+			bind:value={$form.password}
+			errors={$errors.password}
+			autocomplete="new-password"
+			required
+		/>
+
+		<AuthFormField
+			id="confirmPassword"
+			label="Confirm Password"
+			type="password"
+			placeholder="Confirm new password"
+			bind:value={$form.confirmPassword}
+			errors={$errors.confirmPassword}
+			autocomplete="new-password"
+			required
+		/>
+
+		<Button type="submit" class="w-full" disabled={$submitting} aria-busy={$submitting}>
+			{#if $submitting}
+				<Spinner class="mr-2" aria-hidden="true" />
+				Resetting...
+			{:else}
+				Reset Password
 			{/if}
+		</Button>
+	</form>
 
-			<input type="hidden" name="token" bind:value={data.token} />
-
-			<div class="space-y-2">
-				<label for="password" class="block text-sm font-medium">New Password</label>
-				<Input
-					id="password"
-					name="password"
-					type="password"
-					placeholder="Enter new password (min 8 characters)"
-					bind:value={$form.password}
-					class={$errors.password ? 'border-red-400 bg-white/80' : 'bg-white/80'}
-					autocomplete="new-password"
-					required
-				/>
-				{#if $errors.password}
-					<p class="text-sm text-red-200">{$errors.password}</p>
-				{/if}
-			</div>
-
-			<div class="space-y-2">
-				<label for="confirmPassword" class="block text-sm font-medium">Confirm Password</label>
-				<Input
-					id="confirmPassword"
-					name="confirmPassword"
-					type="password"
-					placeholder="Confirm new password"
-					bind:value={$form.confirmPassword}
-					class={$errors.confirmPassword ? 'border-red-400 bg-white/80' : 'bg-white/80'}
-					autocomplete="new-password"
-					required
-				/>
-				{#if $errors.confirmPassword}
-					<p class="text-sm text-red-200">{$errors.confirmPassword}</p>
-				{/if}
-			</div>
-
-			<Button type="submit" class="w-full" disabled={$submitting} aria-busy={$submitting}>
-				{#if $submitting}
-					<Spinner class="mr-2" aria-hidden="true" />
-					Resetting...
-				{:else}
-					Reset Password
-				{/if}
-			</Button>
-		</form>
-
-		<div class="text-center">
-			<p class="text-sm">
-				<a href="/auth/sign-in" class="font-medium underline"> Back to sign in </a>
-			</p>
-		</div>
-	</div>
-</div>
+	{#snippet footer()}
+		<p class="text-sm">
+			<a href="/auth/sign-in" class="font-medium underline"> Back to sign in </a>
+		</p>
+	{/snippet}
+</AuthCardLayout>

--- a/src/routes/auth/sign-in/+page.svelte
+++ b/src/routes/auth/sign-in/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import AuthCardLayout from '$lib/components/AuthCardLayout.svelte';
+	import AuthFormField from '$lib/components/AuthFormField.svelte';
+	import AuthFormMessage from '$lib/components/AuthFormMessage.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Input } from '$lib/components/ui/input';
 	import { Spinner } from '$lib/components/ui/spinner';
 	import { superForm } from 'sveltekit-superforms';
 
@@ -9,91 +11,52 @@
 	let { data }: { data: PageData } = $props();
 
 	// svelte-ignore state_referenced_locally
-	const { form, errors, message, submitting, enhance } = superForm(data.form, {
-		onUpdated: ({ form }) => {
-			if (form.message) {
-				// The error message will be displayed below
-			}
-		}
-	});
+	const { form, errors, message, submitting, enhance } = superForm(data.form);
 </script>
 
-<div class="flex min-h-screen items-center justify-center">
-	<div
-		class="mx-4 w-full max-w-md space-y-6 rounded-xl border border-white/20 bg-white/10 p-8 shadow-2xl backdrop-blur-md"
-	>
-		<div class="text-center">
-			<h1 class="text-3xl font-bold">Sign In</h1>
-			<p class="mt-2">Enter your credentials to access your account</p>
-		</div>
+<AuthCardLayout title="Sign In" description="Enter your credentials to access your account">
+	<form method="POST" class="space-y-4" use:enhance>
+		<AuthFormMessage message={$message} />
 
-		<form method="POST" class="space-y-4" use:enhance>
-			{#if $message}
-				<div
-					class="rounded-md p-4 {$message.includes('successful')
-						? 'bg-green-50/80'
-						: 'bg-red-50/80'} backdrop-blur-sm"
-				>
-					<div
-						class="text-sm {$message.includes('successful') ? 'text-green-700' : 'text-red-700'}"
-					>
-						{$message}
-					</div>
-				</div>
+		<AuthFormField
+			id="email"
+			label="Email"
+			type="email"
+			placeholder="Enter your email"
+			bind:value={$form.email}
+			errors={$errors.email}
+			autocomplete="email"
+			required
+		/>
+
+		<AuthFormField
+			id="password"
+			label="Password"
+			type="password"
+			placeholder="Enter your password"
+			bind:value={$form.password}
+			errors={$errors.password}
+			autocomplete="current-password"
+			required
+		/>
+
+		<Button type="submit" class="w-full" disabled={$submitting} aria-busy={$submitting}>
+			{#if $submitting}
+				<Spinner class="mr-2" aria-hidden="true" />
+				Signing In...
+			{:else}
+				Sign In
 			{/if}
+		</Button>
+	</form>
 
-			<div class="space-y-2">
-				<label for="email" class="block text-sm font-medium">Email</label>
-				<Input
-					id="email"
-					name="email"
-					type="email"
-					placeholder="Enter your email"
-					bind:value={$form.email}
-					class={$errors.email ? 'border-red-400 bg-white/80' : 'bg-white/80'}
-					autocomplete="email"
-					required
-				/>
-				{#if $errors.email}
-					<p class="text-sm text-red-200">{$errors.email}</p>
-				{/if}
-			</div>
-
-			<div class="space-y-2">
-				<label for="password" class="block text-sm font-medium">Password</label>
-				<Input
-					id="password"
-					name="password"
-					type="password"
-					placeholder="Enter your password"
-					bind:value={$form.password}
-					class={$errors.password ? 'border-red-400 bg-white/80' : 'bg-white/80'}
-					autocomplete="current-password"
-					required
-				/>
-				{#if $errors.password}
-					<p class="text-sm text-red-200">{$errors.password}</p>
-				{/if}
-			</div>
-
-			<Button type="submit" class="w-full" disabled={$submitting} aria-busy={$submitting}>
-				{#if $submitting}
-					<Spinner class="mr-2" aria-hidden="true" />
-					Signing In...
-				{:else}
-					Sign In
-				{/if}
-			</Button>
-		</form>
-
-		<div class="space-y-2 text-center">
-			<p class="text-sm">
-				<a href="/auth/forgot-password" class="font-medium underline"> Forgot password? </a>
-			</p>
-			<p class="text-sm">
-				Don't have an account?
-				<a href="/auth/register" class="font-medium underline"> Register here </a>
-			</p>
-		</div>
-	</div>
-</div>
+	{#snippet footer()}
+		<p class="text-sm">
+			<a href="/auth/forgot-password" class="font-medium underline"> Forgot password? </a>
+		</p>
+		<p class="text-sm">
+			Don't have an account?
+			<a href="/auth/register" class="font-medium underline"> Register here </a>
+		</p>
+	{/snippet}
+</AuthCardLayout>


### PR DESCRIPTION
Closes #280

## Problem

The auth card wrapper, superforms message banner, and label/input/error field markup were copy-pasted across `sign-in`, `register`, `forgot-password`, and `reset-password`. Any visual or behavioural tweak meant four identical edits, and the copies had already drifted apart.

## Changes

Three components added to `$lib/components`:

| Component | Responsibility |
| --- | --- |
| `AuthCardLayout.svelte` | Full-height centering, the glass card, the title/description header, and an optional `footer` snippet for the "Sign in here" / "Forgot password?" links. |
| `AuthFormMessage.svelte` | The `$message` banner, including the green-vs-red `includes('successful')` branch. Renders nothing when there is no message, so pages no longer wrap it in `{#if}`. |
| `AuthFormField.svelte` | `<label>` + `<Input>` + error text, with the `border-red-400` error styling. `id` doubles as the input `name`, matching what all four pages already did. |

All four pages now compose these. The no-op `superForm` `onUpdated` handler each page carried (its body was a comment) is removed.

Net: **-341 / +195** lines across the four pages.

## Behaviour

Rendered markup is unchanged, with one deliberate exception: the **register** and **forgot-password** email fields applied the red error border but never rendered the error text. They now render it, matching the other five fields on these pages. Flagging it because the issue asks for unchanged UX — this is the one place where consolidating meant picking a single behaviour, and the fields already signalled the error state visually.

The footer wrapper is `space-y-2 text-center` everywhere; three pages previously used bare `text-center`, but `space-y-*` only affects sibling spacing and those footers have a single child, so there is no visual difference.

## Tests

`AuthCardLayout.test.ts`, `AuthFormMessage.test.ts`, and `AuthFormField.test.ts` added, following the existing `render` from `svelte/server` pattern.

- `npm test` — 279 passed (29 files), up from 269
- `npm run check` — 0 errors, 0 warnings
- `npm run lint` — clean
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)