### PR TITLE
Fix object-shaped $message crashing register, reset-password and profile

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -21,5 +21,12 @@ declare global {
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}
+
+		// Shape of every sveltekit-superforms `message(form, ...)` payload.
+		// Without this declaration superforms falls back to `any`, which let
+		// object payloads reach pages that treated the message as a string.
+		namespace Superforms {
+			type Message = { type: 'error' | 'success'; text: string };
+		}
 	}
 }

--- a/src/lib/components/AuthFormMessage.svelte
+++ b/src/lib/components/AuthFormMessage.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
 	interface Props {
-		message: string | undefined;
+		message: App.Superforms.Message | undefined;
 	}
 
 	let { message }: Props = $props();
 
-	const isSuccess = $derived(message?.includes('successful') ?? false);
+	const isSuccess = $derived(message?.type === 'success');
 </script>
 
 {#if message}
 	<div class="rounded-md p-4 {isSuccess ? 'bg-green-50/80' : 'bg-red-50/80'} backdrop-blur-sm">
 		<div class="text-sm {isSuccess ? 'text-green-700' : 'text-red-700'}">
-			{message}
+			{message.text}
 		</div>
 	</div>
 {/if}

--- a/src/lib/components/AuthFormMessage.test.ts
+++ b/src/lib/components/AuthFormMessage.test.ts
@@ -10,9 +10,9 @@ describe('AuthFormMessage', () => {
 		expect(html).not.toContain('<div');
 	});
 
-	it('renders success styling for messages containing "successful"', () => {
+	it('renders success styling for a success message', () => {
 		const html = render(AuthFormMessage, {
-			props: { message: 'Registration successful! Please sign in.' }
+			props: { message: { type: 'success', text: 'Registration successful! Please sign in.' } }
 		}).body;
 
 		expect(html).toContain('Registration successful! Please sign in.');
@@ -20,13 +20,29 @@ describe('AuthFormMessage', () => {
 		expect(html).toContain('text-green-700');
 	});
 
-	it('renders error styling for any other message', () => {
+	it('renders error styling for an error message', () => {
 		const html = render(AuthFormMessage, {
-			props: { message: 'Invalid email or password' }
+			props: { message: { type: 'error', text: 'Invalid email or password' } }
 		}).body;
 
 		expect(html).toContain('Invalid email or password');
 		expect(html).toContain('bg-red-50/80');
 		expect(html).toContain('text-red-700');
+	});
+
+	it('styles from the type rather than the wording of the text', () => {
+		// The old implementation sniffed for "successful" in the text, which mis-styled
+		// forgot-password's success message as an error.
+		const html = render(AuthFormMessage, {
+			props: {
+				message: {
+					type: 'success',
+					text: 'If an account exists with that email, you will receive a password reset link.'
+				}
+			}
+		}).body;
+
+		expect(html).toContain('bg-green-50/80');
+		expect(html).not.toContain('bg-red-50/80');
 	});
 });

--- a/src/lib/server/actions/auth-form-handler.test.ts
+++ b/src/lib/server/actions/auth-form-handler.test.ts
@@ -1,4 +1,6 @@
+import AuthFormMessage from '$lib/components/AuthFormMessage.svelte';
 import { redirect } from '@sveltejs/kit';
+import { render } from 'svelte/server';
 import { superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 import { describe, expect, it } from 'vitest';
@@ -22,8 +24,7 @@ describe('handleAuthFormAction', () => {
 				},
 				{
 					loggerContext: 'test',
-					fallbackMessage: 'fallback',
-					buildErrorPayload: (errorMessage) => errorMessage
+					fallbackMessage: 'fallback'
 				}
 			)
 		).rejects.toMatchObject({
@@ -41,8 +42,7 @@ describe('handleAuthFormAction', () => {
 			},
 			{
 				loggerContext: 'test',
-				fallbackMessage: 'fallback',
-				buildErrorPayload: (errorMessage) => ({ type: 'error', text: errorMessage })
+				fallbackMessage: 'fallback'
 			}
 		);
 
@@ -55,5 +55,49 @@ describe('handleAuthFormAction', () => {
 				})
 			}
 		});
+	});
+
+	it('honours errorType so a route can keep failures indistinguishable from successes', async () => {
+		const form = await superValidate(zod4(testSchema));
+		const result = await handleAuthFormAction(
+			form,
+			async () => {
+				throw new Error('boom');
+			},
+			{
+				loggerContext: 'test',
+				fallbackMessage: 'If an account exists with that email, you will receive a link.',
+				errorType: 'success'
+			}
+		);
+
+		expect(result).toMatchObject({
+			data: {
+				form: expect.objectContaining({
+					message: {
+						type: 'success',
+						text: 'If an account exists with that email, you will receive a link.'
+					}
+				})
+			}
+		});
+	});
+
+	it('produces a payload the auth banner can actually render', async () => {
+		// Regression guard for #295: register and reset-password sent an object while
+		// the pages called `.includes()` on it, throwing "includes is not a function".
+		const form = await superValidate(zod4(testSchema));
+		const result = (await handleAuthFormAction(
+			form,
+			async () => {
+				throw new Error('boom');
+			},
+			{ loggerContext: 'test', fallbackMessage: 'Registration failed. Please try again.' }
+		)) as { data: { form: { message: App.Superforms.Message } } };
+
+		const html = render(AuthFormMessage, { props: { message: result.data.form.message } }).body;
+
+		expect(html).toContain('Registration failed. Please try again.');
+		expect(html).toContain('bg-red-50/80');
 	});
 });

--- a/src/lib/server/actions/auth-form-handler.ts
+++ b/src/lib/server/actions/auth-form-handler.ts
@@ -9,7 +9,12 @@ type MessageOptions = NonNullable<Parameters<typeof message>[2]>;
 interface AuthFormActionOptions {
 	loggerContext: string;
 	fallbackMessage: string;
-	buildErrorPayload: (errorMessage: string) => Parameters<typeof message>[1];
+	/**
+	 * Banner style for the failure path. Defaults to `'error'`; routes that must
+	 * stay indistinguishable between success and failure (see forgot-password,
+	 * which hides whether an account exists) pass `'success'` instead.
+	 */
+	errorType?: App.Superforms.Message['type'];
 	status?: MessageOptions['status'];
 }
 
@@ -28,8 +33,10 @@ export async function handleAuthFormAction<TForm extends Record<string, unknown>
 		logger.error(options.loggerContext, error);
 		const errorMessage = getBetterAuthErrorMessage(error, options.fallbackMessage);
 
-		return message(form, options.buildErrorPayload(errorMessage), {
-			status: (options.status ?? 400) as MessageOptions['status']
-		});
+		return message(
+			form,
+			{ type: options.errorType ?? 'error', text: errorMessage },
+			{ status: (options.status ?? 400) as MessageOptions['status'] }
+		);
 	}
 }

--- a/src/lib/server/actions/form-message.test.ts
+++ b/src/lib/server/actions/form-message.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { formMessageFromUrl } from './form-message';
+
+const at = (path: string) => new URL(path, 'https://example.test');
+
+describe('formMessageFromUrl', () => {
+	it('returns undefined when no message is present', () => {
+		expect(formMessageFromUrl(at('/auth/sign-in'))).toBeUndefined();
+	});
+
+	it('reads an explicit success message', () => {
+		expect(
+			formMessageFromUrl(
+				at('/auth/sign-in?message=Password%20reset%20successful&messageType=success')
+			)
+		).toEqual({ type: 'success', text: 'Password reset successful' });
+	});
+
+	it('reads an explicit error message', () => {
+		expect(
+			formMessageFromUrl(
+				at('/auth/sign-in?message=Invalid%20verification%20link&messageType=error')
+			)
+		).toEqual({ type: 'error', text: 'Invalid verification link' });
+	});
+
+	it('falls back to error when the type is missing or unrecognised', () => {
+		// The query string is attacker-controllable, so an unlabelled message must not
+		// be able to present itself with the authority of a success banner.
+		expect(
+			formMessageFromUrl(at('/auth/sign-in?message=Your%20account%20is%20verified'))?.type
+		).toBe('error');
+		expect(
+			formMessageFromUrl(at('/auth/sign-in?message=Nice%20try&messageType=SUCCESS'))?.type
+		).toBe('error');
+	});
+});

--- a/src/lib/server/actions/form-message.ts
+++ b/src/lib/server/actions/form-message.ts
@@ -1,0 +1,20 @@
+/**
+ * Reads a superforms banner message handed over through the query string, e.g.
+ * `/auth/sign-in?message=Password%20reset%20successful&messageType=success`.
+ *
+ * The type is carried explicitly rather than inferred from the text, so callers
+ * cannot accidentally style a success as a failure. Anything without an explicit
+ * `messageType=success` is treated as an error, since the query string is
+ * attacker-controllable and a green banner carries more authority than a red one.
+ */
+export function formMessageFromUrl(url: URL): App.Superforms.Message | undefined {
+	const text = url.searchParams.get('message');
+	if (!text) {
+		return undefined;
+	}
+
+	return {
+		type: url.searchParams.get('messageType') === 'success' ? 'success' : 'error',
+		text
+	};
+}

--- a/src/routes/(app)/profile/+page.svelte
+++ b/src/routes/(app)/profile/+page.svelte
@@ -19,11 +19,8 @@
 	// svelte-ignore state_referenced_locally
 	const profileFormStore = superForm(data.profileForm, {
 		onUpdate: ({ form }) => {
-			if (form.message) {
-				// Reset editing state on success
-				if (form.message.includes('successfully')) {
-					isEditingProfile = false;
-				}
+			if (form.message?.type === 'success') {
+				isEditingProfile = false;
 			}
 		}
 	});
@@ -40,11 +37,8 @@
 	const passwordFormStore = superForm(data.passwordForm, {
 		resetForm: true,
 		onUpdate: ({ form }) => {
-			if (form.message) {
-				// Reset editing state and form on success
-				if (form.message.includes('successfully')) {
-					isEditingPassword = false;
-				}
+			if (form.message?.type === 'success') {
+				isEditingPassword = false;
 			}
 		}
 	});
@@ -110,18 +104,16 @@
 					<div class="space-y-4">
 						{#if $profileMessage}
 							<div
-								class="flex items-center gap-2 rounded-md p-3 {$profileMessage.includes(
-									'successfully'
-								)
+								class="flex items-center gap-2 rounded-md p-3 {$profileMessage.type === 'success'
 									? 'border border-green-200 bg-green-50 text-green-700'
 									: 'border border-red-200 bg-red-50 text-red-700'}"
 							>
-								{#if $profileMessage.includes('successfully')}
+								{#if $profileMessage.type === 'success'}
 									<CheckCircleIcon class="h-4 w-4" />
 								{:else}
 									<AlertCircleIcon class="h-4 w-4" />
 								{/if}
-								<span class="text-sm">{$profileMessage}</span>
+								<span class="text-sm">{$profileMessage.text}</span>
 							</div>
 						{/if}
 						<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -207,18 +199,16 @@
 						<div class="space-y-4">
 							{#if $passwordMessage}
 								<div
-									class="flex items-center gap-2 rounded-md p-3 {$passwordMessage.includes(
-										'successfully'
-									)
+									class="flex items-center gap-2 rounded-md p-3 {$passwordMessage.type === 'success'
 										? 'border border-green-200 bg-green-50 text-green-700'
 										: 'border border-red-200 bg-red-50 text-red-700'}"
 								>
-									{#if $passwordMessage.includes('successfully')}
+									{#if $passwordMessage.type === 'success'}
 										<CheckCircleIcon class="h-4 w-4" />
 									{:else}
 										<AlertCircleIcon class="h-4 w-4" />
 									{/if}
-									<span class="text-sm">{$passwordMessage}</span>
+									<span class="text-sm">{$passwordMessage.text}</span>
 								</div>
 							{/if}
 							<div>

--- a/src/routes/auth/forgot-password/+page.server.ts
+++ b/src/routes/auth/forgot-password/+page.server.ts
@@ -1,5 +1,6 @@
 import { BETTER_AUTH_BASE_URL } from '$app/env/private';
 import { handleAuthFormAction } from '$lib/server/actions/auth-form-handler';
+import { formMessageFromUrl } from '$lib/server/actions/form-message';
 import { auth } from '$lib/server/auth';
 import { fail, redirect } from '@sveltejs/kit';
 import { message, superValidate } from 'sveltekit-superforms';
@@ -20,11 +21,8 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 
 	const form = await superValidate(zod4(forgotSchema));
 
-	// Check for success message from registration
-	const message = url.searchParams.get('message');
-	if (message) {
-		form.message = message;
-	}
+	// Check for a message handed over by a redirect
+	form.message = formMessageFromUrl(url);
 
 	return {
 		form
@@ -54,16 +52,18 @@ export const actions: Actions = {
 				});
 
 				// Don't reveal if the email exists or not for security reasons
-				return message(
-					form,
-					'If an account exists with that email, you will receive a password reset link.'
-				);
+				return message(form, {
+					type: 'success',
+					text: 'If an account exists with that email, you will receive a password reset link.'
+				});
 			},
 			{
 				loggerContext: 'Password reset request failed',
 				fallbackMessage:
 					'If an account exists with that email, you will receive a password reset link.',
-				buildErrorPayload: (errorMessage) => errorMessage
+				// Same text *and* same styling as the success path, so the banner cannot
+				// be used to probe whether an account exists.
+				errorType: 'success'
 			}
 		);
 	}

--- a/src/routes/auth/register/+page.server.ts
+++ b/src/routes/auth/register/+page.server.ts
@@ -1,5 +1,6 @@
 import { registerSchema } from '$lib/formSchemas';
 import { handleAuthFormAction } from '$lib/server/actions/auth-form-handler';
+import { formMessageFromUrl } from '$lib/server/actions/form-message';
 import { auth } from '$lib/server/auth';
 import { redirect } from '@sveltejs/kit';
 import { message, superValidate } from 'sveltekit-superforms';
@@ -14,11 +15,8 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	}
 	const form = await superValidate(zod4(registerSchema));
 
-	// Check for success message from registration
-	const message = url.searchParams.get('message');
-	if (message) {
-		form.message = message;
-	}
+	// Check for a message handed over by a redirect
+	form.message = formMessageFromUrl(url);
 
 	return {
 		form
@@ -55,7 +53,6 @@ export const actions: Actions = {
 			{
 				loggerContext: 'Registration failed',
 				fallbackMessage: 'Registration failed. Please try again.',
-				buildErrorPayload: (errorMessage) => ({ type: 'error', text: errorMessage }),
 				status: 400
 			}
 		);

--- a/src/routes/auth/reset-password/+page.server.ts
+++ b/src/routes/auth/reset-password/+page.server.ts
@@ -70,12 +70,14 @@ export const actions: Actions = {
 					}
 				});
 
-				throw redirect(302, '/auth/sign-in?message=Password reset successful! Please sign in.');
+				throw redirect(
+					302,
+					'/auth/sign-in?message=Password reset successful! Please sign in.&messageType=success'
+				);
 			},
 			{
 				loggerContext: 'Password reset failed',
 				fallbackMessage: 'Failed to reset password. Please try again.',
-				buildErrorPayload: (errorMessage) => ({ type: 'error', text: errorMessage }),
 				status: 400
 			}
 		);

--- a/src/routes/auth/sign-in/+page.server.ts
+++ b/src/routes/auth/sign-in/+page.server.ts
@@ -1,5 +1,6 @@
 import { signInSchema } from '$lib/formSchemas';
 import { handleAuthFormAction } from '$lib/server/actions/auth-form-handler';
+import { formMessageFromUrl } from '$lib/server/actions/form-message';
 import { auth } from '$lib/server/auth';
 import { redirect } from '@sveltejs/kit';
 import { message, superValidate } from 'sveltekit-superforms';
@@ -15,11 +16,8 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 
 	const form = await superValidate(zod4(signInSchema));
 
-	// Check for success message from registration
-	const message = url.searchParams.get('message');
-	if (message) {
-		form.message = message;
-	}
+	// Check for a message handed over by a redirect
+	form.message = formMessageFromUrl(url);
 
 	return {
 		form
@@ -31,7 +29,11 @@ export const actions: Actions = {
 		const form = await superValidate(request, zod4(signInSchema));
 
 		if (!form.valid) {
-			return message(form, 'Please correct the errors in the form.', { status: 400 });
+			return message(
+				form,
+				{ type: 'error', text: 'Please correct the errors in the form.' },
+				{ status: 400 }
+			);
 		}
 
 		return handleAuthFormAction(
@@ -49,8 +51,7 @@ export const actions: Actions = {
 			},
 			{
 				loggerContext: 'Sign-in failed',
-				fallbackMessage: 'An error occurred during sign-in. Please try again.',
-				buildErrorPayload: (errorMessage) => errorMessage
+				fallbackMessage: 'An error occurred during sign-in. Please try again.'
 			}
 		);
 	}

--- a/src/routes/auth/verify-email/+page.server.ts
+++ b/src/routes/auth/verify-email/+page.server.ts
@@ -13,7 +13,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 
 	// If no email provided, redirect to sign-in
 	if (!email) {
-		throw redirect(302, '/auth/sign-in?message=Invalid verification link');
+		throw redirect(302, '/auth/sign-in?message=Invalid verification link&messageType=error');
 	}
 
 	return {


### PR DESCRIPTION
Closes #295

## The bug

`sveltekit-superforms` types its message as `App.Superforms.Message extends never ? any : ...`. `src/app.d.ts` never declared that namespace, so `$message` was `any` and nothing verified that producers and consumers agreed on a shape.

They didn't:

| Route | Server sent | Page expected | Result |
| --- | --- | --- | --- |
| `auth/sign-in` | `string` | string | OK |
| `auth/forgot-password` | `string` | string | OK |
| **`auth/register`** | `{ type, text }` | string | **crash** |
| **`auth/reset-password`** | `{ type, text }` | string | **crash** |
| **`(app)/profile`** | `{ type, text }` | string | **crash** |

Each consumer called `.includes('successful')` on the message to pick the banner colour. Against the object that throws `TypeError: message?.includes is not a function` — a 500 on the SSR fallback.

Reproduce on register with `a@b`, `glenn@localhost`, or `user@internal`: `type="email"` only requires `x@y` per WHATWG, so the browser submits them, while `z.email()` requires a real TLD. The action returns the object payload, the banner throws instead of rendering.

`profile/+page.svelte` had the same mismatch in six places including its **success** path, so `isEditingProfile = false` never ran after a successful save.

This was already fixed once for a single route — `f444c90`, *"prevent sign-in 500 on invalid credentials"* — and reintroduced by #291 via `buildErrorPayload`, whose `Parameters<typeof message>[1]` return type also resolved to `any`.

## Which shape wins

Measured by declaring the type and counting `svelte-check` errors:

- `Message = string` → **54 errors** across modals, admin, profile, budget, recurring
- `Message = { type, text }` → **15 errors**, confined to the 4 auth pages, their servers, and profile

The object is the established convention; the string-sniffing pages were the outlier.

## Changes

- **`src/app.d.ts`** — declare `App.Superforms.Message`. This is the durable part: `$message` is no longer `any`, so a future mismatch is a compile error rather than a runtime throw.
- **`AuthFormMessage.svelte`** — branch on `message.type`, render `message.text`.
- **`profile/+page.svelte`** — six sniff sites become `.type === 'success'`.
- **`auth-form-handler.ts`** — `buildErrorPayload` (the second `any` hole) replaced by an `errorType` option; the handler builds the payload. Removes the identical lambda from all four callers.
- **`sign-in` / `forgot-password` servers** — emit objects.
- **`form-message.ts`** (new) — messages passed by redirect now carry `&messageType` rather than leaving the receiving page to guess from the wording. Anything not explicitly `messageType=success` is treated as an error, since the query string is attacker-controllable and a green banner carries more authority than a red one.

## Two behaviour notes

**forgot-password's success banner was red.** `.includes('successful')` was the colour heuristic, and *"If an account exists with that email, you will receive a password reset link."* contains no `"successful"`. Dropping the sniff fixes it.

**That fix needed care.** forgot-password deliberately returns the same text on success and failure to hide whether an account exists. Making success green while the failure path stayed red would have turned the banner colour into an account-enumeration oracle, so its failure path passes `errorType: 'success'` — both outcomes stay byte-identical. This is why `errorType` is per-route rather than hardcoded to `'error'` in the handler.

## Tests

- `form-message.test.ts` (new) — covers the parse, including the error-by-default fallback for unlabelled and malformed types.
- `auth-form-handler.test.ts` — covers `errorType`, plus an end-to-end guard that feeds a real handler payload into `AuthFormMessage` and asserts it renders. That test fails with `includes is not a function` against the old code.
- `AuthFormMessage.test.ts` — rewritten for the object shape, including a case asserting styling comes from `type` and not the wording.

`npm test` 286 passed (30 files) · `npm run check` 0 errors · `npm run lint` clean · `npm run build` succeeds.

No `.includes('successful')` message sniffing remains in `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)