### PR TITLE
Keep SEARCH_RESULT_LIMIT internal to the transactions query module (#285)

### DIFF
--- a/src/lib/server/db/queries/transactions.test.ts
+++ b/src/lib/server/db/queries/transactions.test.ts
@@ -146,6 +146,10 @@ describe('transactionQueries', () => {
 		type SqlCondition = { type: string; text: string; values: unknown[] };
 		type OrWhere = { type: string; conditions: SqlCondition[] };
 
+		function makeRows(count: number) {
+			return Array.from({ length: count }, (_, index) => ({ id: `txn-${index}` }));
+		}
+
 		function getWhere() {
 			const call = mockState.findAll.mock.lastCall;
 			expect(call).toBeDefined();
@@ -216,6 +220,32 @@ describe('transactionQueries', () => {
 			const where = getWhere();
 			expect(where.conditions[0].values[1]).toBe(String.raw`%50\%\_off\\deal%`);
 			expect(where.conditions[1].values[1]).toBe(String.raw`%50\%\_off\\deal%`);
+		});
+
+		it('caps the query at 200 rows', async () => {
+			await transactionQueries.search('coffee');
+
+			const call = mockState.findAll.mock.lastCall;
+			expect(call).toBeDefined();
+			expect((call![0] as unknown as { limit: number }).limit).toBe(200);
+		});
+
+		it('returns the rows with limitReached false when under the cap', async () => {
+			const rows = makeRows(199);
+			mockState.findAll.mockResolvedValue(rows);
+
+			const result = await transactionQueries.search('coffee');
+
+			expect(result.transactions).toEqual(rows);
+			expect(result.limitReached).toBe(false);
+		});
+
+		it('flags limitReached when the result set fills the cap', async () => {
+			mockState.findAll.mockResolvedValue(makeRows(200));
+
+			const result = await transactionQueries.search('coffee');
+
+			expect(result.limitReached).toBe(true);
 		});
 	});
 });

--- a/src/lib/server/db/queries/transactions.ts
+++ b/src/lib/server/db/queries/transactions.ts
@@ -8,7 +8,8 @@ import { createQueryBuilder } from './factory';
 // B-tree index, so this limits the work done per interactive query. If the table grows
 // to a scale where this bound is regularly hit, replace with an SQLite FTS5 virtual
 // table and use MATCH instead of LIKE.
-export const SEARCH_RESULT_LIMIT = 200;
+// Kept module-private: callers read `limitReached` off the search result instead.
+const SEARCH_RESULT_LIMIT = 200;
 
 const baseBuilder = createQueryBuilder<typeof transaction, Transaction>({
 	tableName: 'transaction',
@@ -84,8 +85,11 @@ export const transactionQueries = {
 
 	// Search across all transactions by payee or notes (cross-month).
 	// Bounded to SEARCH_RESULT_LIMIT rows to prevent unbounded full-table scans;
-	// a leading-wildcard LIKE cannot use a B-tree index.
-	search: async (query: string): Promise<Transaction[]> => {
+	// a leading-wildcard LIKE cannot use a B-tree index. `limitReached` reports whether the
+	// cap truncated the result set so callers can warn without knowing the limit itself.
+	search: async (
+		query: string
+	): Promise<{ transactions: Transaction[]; limitReached: boolean }> => {
 		// Escape LIKE wildcards (\, %, _) so user input is treated as a literal string.
 		// The ESCAPE clause tells SQLite that \ is the escape character in the pattern.
 		const escaped = query
@@ -93,13 +97,14 @@ export const transactionQueries = {
 			.replaceAll('%', String.raw`\%`)
 			.replaceAll('_', String.raw`\_`);
 		const pattern = `%${escaped}%`;
-		return baseBuilder.findAll({
+		const transactions = await baseBuilder.findAll({
 			where: or(
 				sql`${transaction.payee} LIKE ${pattern} ESCAPE '\\'`,
 				sql`${transaction.notes} LIKE ${pattern} ESCAPE '\\'`
 			),
 			limit: SEARCH_RESULT_LIMIT
 		});
+		return { transactions, limitReached: transactions.length >= SEARCH_RESULT_LIMIT };
 	},
 
 	// Find by date range excluding a specific category (for business receipts)

--- a/src/routes/(app)/finances/transactions/+page.server.ts
+++ b/src/routes/(app)/finances/transactions/+page.server.ts
@@ -1,7 +1,6 @@
 import { transactionSchema } from '$lib/formSchemas';
 import { createCrudActions } from '$lib/server/actions/crud-helpers';
 import { budgetQueries, transactionQueries } from '$lib/server/db/queries';
-import { SEARCH_RESULT_LIMIT } from '$lib/server/db/queries/transactions';
 import { transaction } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logger';
 import { transactionBudgetAlertHooks } from '$lib/server/notifications/budget-threshold-alerts';
@@ -29,7 +28,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	try {
 		// In search mode: query across all months, skip budget data (sidebar is hidden)
 		if (searchQuery) {
-			const transactions = await transactionQueries.search(searchQuery);
+			const { transactions, limitReached } = await transactionQueries.search(searchQuery);
 			return {
 				transactions,
 				budgets: [],
@@ -39,7 +38,7 @@ export const load: PageServerLoad = async ({ url }) => {
 				completedMonthsSinceJanuary: 0,
 				form,
 				searchQuery,
-				searchLimitReached: transactions.length >= SEARCH_RESULT_LIMIT
+				searchLimitReached: limitReached
 			};
 		}
 


### PR DESCRIPTION
Closes #285

## Problem

`SEARCH_RESULT_LIMIT` was exported from `src/lib/server/db/queries/transactions.ts` for a single consumer — the transactions route imported it only to compute `transactions.length >= SEARCH_RESULT_LIMIT`. That leaks an internal tuning knob into the module's public API and couples the route to how the query bounds itself.

## Fix

- `SEARCH_RESULT_LIMIT` is now a module-private `const`.
- `transactionQueries.search()` returns `{ transactions, limitReached }` instead of a bare array, so callers get the truncation signal without knowing the limit value.
- The route destructures the result and passes `limitReached` straight through as `searchLimitReached`.

## Behaviour

Unchanged. `searchLimitReached` is computed with the same `>= SEARCH_RESULT_LIMIT` comparison, just on the other side of the module boundary, and `+page.svelte` still renders the same "refine your search" hint.

## Tests

Existing `search` tests (LIKE escaping, OR condition shape) pass unmodified. Added three cases in `src/lib/server/db/queries/transactions.test.ts`:

- the query is capped at 200 rows
- `limitReached` is `false` and the rows pass through when under the cap
- `limitReached` is `true` when the result set fills the cap

`npm run check:all` (fmt + lint + 289 tests) and `npm run check` (svelte-check, 0 errors) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)