### PR TITLE
Replace locals.user! in loads with typed requireUser guard (#289)

### DIFF
--- a/src/lib/server/auth-guard-load.test.ts
+++ b/src/lib/server/auth-guard-load.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRedirect = vi.hoisted(() =>
+	vi.fn<(status: number, location: string) => never>((status, location) => {
+		throw new Error(`redirect ${status} ${location}`);
+	})
+);
+
+vi.mock('@sveltejs/kit', () => ({
+	redirect: mockRedirect
+}));
+
+import { requireUser, SIGN_IN_ROUTE } from './auth-guard-load';
+
+describe('requireUser', () => {
+	beforeEach(() => {
+		mockRedirect.mockClear();
+	});
+
+	it('redirects to sign-in when user is missing', () => {
+		const locals = { user: undefined } as App.Locals;
+
+		expect(() => requireUser(locals)).toThrow(`redirect 302 ${SIGN_IN_ROUTE}`);
+		expect(mockRedirect).toHaveBeenCalledWith(302, SIGN_IN_ROUTE);
+	});
+
+	it('returns the authenticated user when present', () => {
+		const user = { id: 'user-123' };
+		const locals = { user } as unknown as App.Locals;
+
+		expect(requireUser(locals)).toBe(user);
+		expect(mockRedirect).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/server/auth-guard-load.ts
+++ b/src/lib/server/auth-guard-load.ts
@@ -1,0 +1,35 @@
+import { redirect } from '@sveltejs/kit';
+
+/**
+ * Type representing an authenticated user from locals
+ */
+type AuthenticatedUser = NonNullable<App.Locals['user']>;
+
+/**
+ * Where unauthenticated visitors are sent.
+ */
+export const SIGN_IN_ROUTE = '/auth/sign-in';
+
+/**
+ * Returns the authenticated user, or redirects to sign-in.
+ *
+ * Use this in `load` functions, where a redirect is the correct response.
+ * Actions should use `requireAuth` from `$lib/server/actions/auth-guard`
+ * instead, since they must return a `fail()` rather than redirect.
+ *
+ * @param locals - The request locals populated by `hooks.server.ts`
+ * @returns The authenticated user, narrowed to be non-nullable
+ *
+ * @example
+ * export const load: PageServerLoad = async ({ locals }) => {
+ *   const user = requireUser(locals);
+ *   // user is guaranteed to be defined here
+ * };
+ */
+export function requireUser(locals: App.Locals): AuthenticatedUser {
+	if (!locals.user) {
+		throw redirect(302, SIGN_IN_ROUTE);
+	}
+
+	return locals.user;
+}

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -1,3 +1,4 @@
+import { SIGN_IN_ROUTE } from '$lib/server/auth-guard-load';
 import { categoryQueries } from '$lib/server/db/queries';
 import { logger } from '$lib/server/logger';
 import { redirect } from '@sveltejs/kit';
@@ -14,7 +15,7 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 
 	// Redirect to sign-in if not authenticated for other routes
 	if (!locals.user) {
-		throw redirect(302, '/auth/sign-in');
+		throw redirect(302, SIGN_IN_ROUTE);
 	}
 
 	try {

--- a/src/routes/(app)/profile/+page.server.ts
+++ b/src/routes/(app)/profile/+page.server.ts
@@ -1,6 +1,7 @@
 import { changePasswordSchema, updateProfileSchema } from '$lib/formSchemas';
 import { requireAuth } from '$lib/server/actions/auth-guard';
 import { auth } from '$lib/server/auth';
+import { requireUser } from '$lib/server/auth-guard-load';
 import { getDb } from '$lib/server/db';
 import { accountQueries, userQueries } from '$lib/server/db/queries';
 import { user } from '$lib/server/db/schema';
@@ -13,7 +14,7 @@ import { zod4 } from 'sveltekit-superforms/adapters';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const currentUser = locals.user!;
+	const currentUser = requireUser(locals);
 
 	// Get the full user data including updatedAt
 	const fullUserData = await userQueries.findById(currentUser.id);

--- a/src/routes/(app)/setup/recurring/+page.server.ts
+++ b/src/routes/(app)/setup/recurring/+page.server.ts
@@ -1,6 +1,7 @@
 import { recurringSchema, togglePaidSchema } from '$lib/formSchemas/finances';
 import { requireAuth } from '$lib/server/actions/auth-guard';
 import { createCrudActions } from '$lib/server/actions/crud-helpers';
+import { requireUser } from '$lib/server/auth-guard-load';
 import { getDb } from '$lib/server/db';
 import { recurringQueries } from '$lib/server/db/queries';
 import { recurring } from '$lib/server/db/schema';
@@ -13,7 +14,7 @@ import { zod4 } from 'sveltekit-superforms/adapters';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const user = locals.user!;
+	const user = requireUser(locals);
 	const recurrings = await recurringQueries.findAll({
 		where: eq(recurring.userId, user.id)
 	});


### PR DESCRIPTION
Closes #289.

## Problem

`profile/+page.server.ts` and `setup/recurring/+page.server.ts` asserted `locals.user!` in their `load` functions. They were safe only because `(app)/+layout.server.ts` redirects unauthenticated requests — a guarantee invisible to the type checker and to anyone reading those two files.

## Is it actually broken?

Not user-visibly, no. But it's slightly worse than "just a type smell":

SvelteKit fires all server loads for a route in parallel (`@sveltejs/kit/src/runtime/server/page/index.js:179-282`). I confirmed with a temporary probe that on an unauthenticated hit to `/profile` the leaf load **does** execute with `locals.user === undefined`, so `currentUser.id` threw a `TypeError`. The result-collection loop walks nodes parent-first, so the layout's `Redirect` is awaited first and wins — and the sibling rejection is swallowed by `p.catch(noop)`, never reaching `handleError`.

So: users always got the correct 302, nothing was ever logged, and there was no security hole. The load was simply failing internally on every unauthenticated hit to these two routes. This PR makes it redirect deliberately instead.

## Changes

- **New `src/lib/server/auth-guard-load.ts`** — `requireUser(locals)` returns the user narrowed to `NonNullable<App.Locals['user']>`, or throws `redirect(302, SIGN_IN_ROUTE)`.
- **Both `!` sites replaced.** Actions in both files already used `requireAuth` and are untouched.
- **`SIGN_IN_ROUTE` exported and used by `(app)/+layout.server.ts`**, so the redirect target is defined once.
- **New `auth-guard-load.test.ts`** — follows the `vi.hoisted` + `vi.mock('@sveltejs/kit')` pattern from `actions/auth-guard.test.ts`.

### Why a plain guard, not the `requireAuthLoad` HOF the issue proposed

`requireAuth` has to be a higher-order function because actions must *return* `fail()`, which a guard cannot do. Loads *throw* `redirect`, so a plain function is sufficient — and it avoids the generic-inference fragility of wrapping a `PageServerLoad`-annotated export. It also works unchanged in actions and `+server.ts` endpoints.

## Verification

- `npm run fmt:check`, `npm run check` (0 errors / 0 warnings), `npm run lint` (incl. `check:dead-exports`, `check:redirect-throws`) — all clean
- `npm run test` — 291/291 passing
- Dev server, signed out: `/profile` and `/setup/recurring` → 302 to `/auth/sign-in`; `/auth/sign-in` → 200

## Not in this PR

Enabling `typescript/no-non-null-assertion` — without it, nothing stops this pattern reappearing. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)