### PR TITLE
Scope navigation feedback so per-route skeletons can paint

### DIFF
--- a/src/lib/components/CardGridSkeleton.svelte
+++ b/src/lib/components/CardGridSkeleton.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { Skeleton } from '$lib/components/ui/skeleton';
+
+	interface Props {
+		/** Number of card placeholders to render. */
+		cards?: number;
+		/** Grid/flex classes for the container, supplied by the caller so the
+		 * placeholder occupies the same footprint as the content it replaces. */
+		class?: string;
+		/** Body lines inside each card, below the title bar. */
+		linesPerCard?: number;
+		/** Height of each card's body lines, e.g. `h-4` for text, `h-40` for a chart. */
+		lineClass?: string;
+		/** Accessible description of what is loading. */
+		label?: string;
+	}
+
+	let {
+		cards = 2,
+		class: className = 'flex flex-col gap-6',
+		linesPerCard = 2,
+		lineClass = 'h-4',
+		label = 'Loading'
+	}: Props = $props();
+</script>
+
+<div class={className} role="status">
+	<span class="sr-only">{label}</span>
+
+	{#each Array.from({ length: cards }) as _card, cardIndex (cardIndex)}
+		<div class="overflow-hidden rounded-lg border shadow">
+			<div class="space-y-4 p-6">
+				<Skeleton class="mx-auto h-6 w-40" />
+				<div class="border-t"></div>
+				{#each Array.from({ length: linesPerCard }) as _line, lineIndex (lineIndex)}
+					<Skeleton class="{lineClass} w-full" />
+				{/each}
+			</div>
+		</div>
+	{/each}
+</div>

--- a/src/lib/components/CardGridSkeleton.test.ts
+++ b/src/lib/components/CardGridSkeleton.test.ts
@@ -1,0 +1,60 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+
+import CardGridSkeleton from './CardGridSkeleton.svelte';
+
+function countSkeletons(html: string): number {
+	return html.split('data-slot="skeleton"').length - 1;
+}
+
+describe('CardGridSkeleton', () => {
+	it('renders one title bar plus the requested body lines per card', () => {
+		const html = render(CardGridSkeleton, { props: { cards: 3, linesPerCard: 2 } }).body;
+
+		// 3 cards * (1 title + 2 lines)
+		expect(countSkeletons(html)).toBe(9);
+	});
+
+	it('defaults to two cards with two lines each', () => {
+		const html = render(CardGridSkeleton).body;
+
+		expect(countSkeletons(html)).toBe(6);
+	});
+
+	it('reuses the card frame so the layout does not shift on swap', () => {
+		const html = render(CardGridSkeleton, { props: { cards: 1 } }).body;
+
+		expect(html).toContain('overflow-hidden rounded-lg border shadow');
+	});
+
+	it('applies the caller-supplied container classes', () => {
+		const html = render(CardGridSkeleton, {
+			props: { cards: 4, class: 'grid grid-cols-2 gap-4 sm:grid-cols-4' }
+		}).body;
+
+		expect(html).toContain('grid grid-cols-2 gap-4 sm:grid-cols-4');
+	});
+
+	it('applies a custom line height for chart-sized placeholders', () => {
+		const html = render(CardGridSkeleton, {
+			props: { cards: 1, linesPerCard: 1, lineClass: 'h-40' }
+		}).body;
+
+		expect(html).toContain('h-40');
+	});
+
+	it('exposes a status role with a customizable label', () => {
+		const html = render(CardGridSkeleton, {
+			props: { cards: 1, label: 'Loading dashboard' }
+		}).body;
+
+		expect(html).toContain('role="status"');
+		expect(html).toContain('Loading dashboard');
+	});
+
+	it('renders pulsing placeholders', () => {
+		const html = render(CardGridSkeleton, { props: { cards: 1 } }).body;
+
+		expect(html).toContain('animate-pulse');
+	});
+});

--- a/src/lib/components/LoadingSpinner.svelte
+++ b/src/lib/components/LoadingSpinner.svelte
@@ -16,13 +16,13 @@
 {#if fullScreen}
 	<div class="fixed inset-0 flex items-center justify-center">
 		<div
-			class="{sizeClasses[size]} animate-spin rounded-full border-black border-t-transparent"
+			class="{sizeClasses[size]} border-foreground animate-spin rounded-full border-t-transparent"
 		></div>
 	</div>
 {:else}
 	<div class="flex items-center justify-center">
 		<div
-			class="{sizeClasses[size]} animate-spin rounded-full border-black border-t-transparent"
+			class="{sizeClasses[size]} border-foreground animate-spin rounded-full border-t-transparent"
 		></div>
 	</div>
 {/if}

--- a/src/lib/components/MonthlyTablePageShell.svelte
+++ b/src/lib/components/MonthlyTablePageShell.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
+	import CardGridSkeleton from '$lib/components/CardGridSkeleton.svelte';
 	import MonthYearSwitcher from '$lib/components/MonthYearSwitcher.svelte';
+	import TableSkeleton from '$lib/components/TableSkeleton.svelte';
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { months } from '$lib/utils';
+	import { usePendingReload } from '$lib/utils/pendingNavigation.svelte';
 	import type { Snippet } from 'svelte';
 
 	interface Props {
@@ -19,6 +22,9 @@
 		tableColumnClass?: string;
 		summaryColumnClass?: string;
 		showSummary?: boolean;
+		skeletonRows?: number;
+		skeletonColumns?: number;
+		skeletonSummaryCards?: number;
 	}
 
 	let {
@@ -35,8 +41,15 @@
 		mainClass = 'flex flex-col gap-6 lg:grid lg:grid-cols-4',
 		tableColumnClass = 'lg:col-span-3',
 		summaryColumnClass = 'lg:col-span-1',
-		showSummary = true
+		showSummary = true,
+		skeletonRows = 8,
+		skeletonColumns = 5,
+		skeletonSummaryCards = 2
 	}: Props = $props();
+
+	// A month/year switch is a same-route navigation: keep the frame and the
+	// controls interactive, and skeleton only the regions fed by `data`.
+	const reloading = usePendingReload();
 </script>
 
 <div class="px-4 py-6 sm:px-0">
@@ -89,14 +102,26 @@
 							</div>
 						{/if}
 					</div>
-					{@render tableContent()}
+					{#if reloading.current}
+						<TableSkeleton rows={skeletonRows} columns={skeletonColumns} />
+					{:else}
+						{@render tableContent()}
+					{/if}
 				</div>
 			</div>
 		</div>
 
 		{#if showSummary && summaryContent}
 			<div class={summaryColumnClass}>
-				{@render summaryContent()}
+				{#if reloading.current}
+					<CardGridSkeleton
+						cards={skeletonSummaryCards}
+						class="flex flex-col gap-6"
+						label="Loading summary"
+					/>
+				{:else}
+					{@render summaryContent()}
+				{/if}
 			</div>
 		{/if}
 	</div>

--- a/src/lib/components/TableSkeleton.svelte
+++ b/src/lib/components/TableSkeleton.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { Skeleton } from '$lib/components/ui/skeleton';
+
+	interface Props {
+		rows?: number;
+		columns?: number;
+	}
+
+	let { rows = 5, columns = 5 }: Props = $props();
+
+	// Generate column widths with some variety
+	const columnWidths = ['w-24', 'w-32', 'w-20', 'w-28', 'w-16', 'w-36'];
+
+	function getColumnWidth(index: number): string {
+		return columnWidths[index % columnWidths.length];
+	}
+</script>
+
+<div class="space-y-4" role="status">
+	<span class="sr-only">Loading table data</span>
+
+	<!-- Table header skeleton -->
+	<div class="flex space-x-4">
+		{#each Array.from({ length: columns }) as _col, i (i)}
+			<Skeleton class="h-6 {getColumnWidth(i)}" />
+		{/each}
+	</div>
+
+	<!-- Table rows skeleton -->
+	{#each Array.from({ length: rows }) as _row, rowIndex (rowIndex)}
+		<div class="flex space-x-4">
+			{#each Array.from({ length: columns }) as _col2, colIndex (`${rowIndex}-${colIndex}`)}
+				<Skeleton class="h-4 {getColumnWidth(colIndex)}" />
+			{/each}
+		</div>
+	{/each}
+</div>

--- a/src/lib/components/TableSkeleton.test.ts
+++ b/src/lib/components/TableSkeleton.test.ts
@@ -1,0 +1,51 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+
+import TableSkeleton from './TableSkeleton.svelte';
+
+function countSkeletons(html: string): number {
+	return html.split('data-slot="skeleton"').length - 1;
+}
+
+describe('TableSkeleton', () => {
+	it('renders a header row plus the requested body rows', () => {
+		const html = render(TableSkeleton, { props: { rows: 3, columns: 4 } }).body;
+
+		// (3 body rows + 1 header row) * 4 columns
+		expect(countSkeletons(html)).toBe(16);
+	});
+
+	it('defaults to a 5x5 grid', () => {
+		const html = render(TableSkeleton).body;
+
+		expect(countSkeletons(html)).toBe(30);
+	});
+
+	it('renders pulsing placeholders', () => {
+		const html = render(TableSkeleton, { props: { rows: 1, columns: 1 } }).body;
+
+		expect(html).toContain('animate-pulse');
+	});
+
+	it('exposes a status role with an accessible label', () => {
+		const html = render(TableSkeleton, { props: { rows: 1, columns: 1 } }).body;
+
+		expect(html).toContain('role="status"');
+		expect(html).toContain('Loading table data');
+	});
+
+	it('cycles column widths from the defined scale only', () => {
+		const html = render(TableSkeleton, { props: { rows: 1, columns: 8 } }).body;
+
+		// w-18 and w-30 are not on Tailwind's default scale and must not appear
+		expect(html).not.toContain('w-18');
+		expect(html).not.toContain('w-30');
+		expect(html).toContain('w-24');
+	});
+
+	it('renders nothing but the header when rows is zero', () => {
+		const html = render(TableSkeleton, { props: { rows: 0, columns: 3 } }).body;
+
+		expect(countSkeletons(html)).toBe(3);
+	});
+});

--- a/src/lib/utils/navigation.test.ts
+++ b/src/lib/utils/navigation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyNavigation } from './navigation';
+
+describe('classifyNavigation', () => {
+	it('returns idle when no navigation is in flight', () => {
+		expect(classifyNavigation(undefined, '/(app)/finances/income')).toBe('idle');
+	});
+
+	it('returns idle even when the current route is unknown', () => {
+		expect(classifyNavigation(undefined, null)).toBe('idle');
+	});
+
+	it('returns same-route for a month switch on the current route', () => {
+		expect(classifyNavigation('/(app)/finances/income', '/(app)/finances/income')).toBe(
+			'same-route'
+		);
+	});
+
+	it('returns cross-route when navigating to a different route', () => {
+		expect(classifyNavigation('/(app)/dashboard', '/(app)/finances/income')).toBe('cross-route');
+	});
+
+	it('returns cross-route when the target is not a SvelteKit route', () => {
+		expect(classifyNavigation(null, '/(app)/finances/income')).toBe('cross-route');
+	});
+
+	it('returns same-route when both route ids are null', () => {
+		expect(classifyNavigation(null, null)).toBe('same-route');
+	});
+});

--- a/src/lib/utils/navigation.ts
+++ b/src/lib/utils/navigation.ts
@@ -1,0 +1,31 @@
+/**
+ * Navigation Classification
+ *
+ * Distinguishes a same-route navigation (a search-param change such as a month
+ * or year switch) from a cross-route one. Same-route navigations should keep
+ * the page frame mounted and skeleton only the data regions; cross-route
+ * navigations replace the whole view.
+ *
+ * Kept free of `$app/state` imports so it stays unit-testable.
+ */
+
+export type NavigationKind = 'idle' | 'same-route' | 'cross-route';
+
+/**
+ * Classify an in-flight navigation.
+ *
+ * Call sites pass `navigating.to?.route.id` directly:
+ * - `undefined` means no navigation is in flight.
+ * - `null` means the target is not a SvelteKit-owned route, which counts as
+ *   cross-route.
+ */
+export function classifyNavigation(
+	toRouteId: string | null | undefined,
+	currentRouteId: string | null
+): NavigationKind {
+	if (toRouteId === undefined) {
+		return 'idle';
+	}
+
+	return toRouteId === currentRouteId ? 'same-route' : 'cross-route';
+}

--- a/src/lib/utils/pendingNavigation.svelte.ts
+++ b/src/lib/utils/pendingNavigation.svelte.ts
@@ -1,0 +1,46 @@
+import { navigating, page } from '$app/state';
+
+import { classifyNavigation } from './navigation';
+
+/**
+ * How long a same-route navigation must run before a skeleton is shown.
+ *
+ * Local SQLite loads are frequently well under this, and a skeleton that
+ * flashes for a few frames reads as a glitch. Below the threshold the previous
+ * content simply stays put until the new data lands.
+ */
+const SKELETON_DELAY_MS = 150;
+
+/**
+ * Tracks whether the current route is reloading its own data — i.e. a
+ * search-param change such as a month or year switch — for longer than
+ * `delayMs`.
+ *
+ * Must be called during component initialisation, since it registers an
+ * `$effect`.
+ */
+export function usePendingReload(delayMs: number = SKELETON_DELAY_MS) {
+	let pending = $state(false);
+
+	$effect(() => {
+		if (classifyNavigation(navigating.to?.route.id, page.route.id) !== 'same-route') {
+			pending = false;
+			return;
+		}
+
+		const timer = setTimeout(() => {
+			pending = true;
+		}, delayMs);
+
+		return () => {
+			clearTimeout(timer);
+			pending = false;
+		};
+	});
+
+	return {
+		get current() {
+			return pending;
+		}
+	};
+}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-	import { navigating } from '$app/state';
+	import { navigating, page } from '$app/state';
 	import AppSidebar from '$lib/components/AppSidebar.svelte';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import SiteHeader from '$lib/components/SiteHeader.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { setCategoriesContext } from '$lib/contexts';
+	import { classifyNavigation } from '$lib/utils/navigation';
 
 	import { sidebarData } from './sidebarData';
 
@@ -14,6 +15,12 @@
 
 	// svelte-ignore state_referenced_locally
 	setCategoriesContext(data.categories ?? []);
+
+	// Only a genuine route change replaces the page. Same-route navigations
+	// (month/year switches) keep the page mounted so it can skeleton in place.
+	let isCrossRouteNavigation = $derived(
+		classifyNavigation(navigating.to?.route.id, page.route.id) === 'cross-route'
+	);
 </script>
 
 <Sidebar.Provider style="--header-height: calc(var(--spacing) * 12);">
@@ -22,7 +29,7 @@
 		<Sidebar.Inset>
 			<SiteHeader />
 			<main class="flex flex-1 flex-col space-y-4 p-4 md:py-2">
-				{#if navigating.to}
+				{#if isCrossRouteNavigation}
 					<LoadingSpinner fullScreen={true} size="lg" />
 				{:else}
 					{@render children()}

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -6,6 +6,7 @@
 	import BudgetAlertRow from '$lib/components/BudgetAlertRow.svelte';
 	import BudgetProgressCard from '$lib/components/BudgetProgressCard.svelte';
 	import CardBeam from '$lib/components/CardBeam.svelte';
+	import CardGridSkeleton from '$lib/components/CardGridSkeleton.svelte';
 	import CashFlowProjectionCard from '$lib/components/CashFlowProjectionCard.svelte';
 	import CategoryTransactionSheet from '$lib/components/CategoryTransactionSheet.svelte';
 	import GoalsSummaryStrip from '$lib/components/GoalsSummaryStrip.svelte';
@@ -25,6 +26,7 @@
 	import WindowCleaningSummaryCard from '$lib/components/WindowCleaningSummaryCard.svelte';
 	import { getCategoriesContext } from '$lib/contexts';
 	import { formatCurrency, monthNames, months } from '$lib/utils';
+	import { usePendingReload } from '$lib/utils/pendingNavigation.svelte';
 	import { ChevronDownIcon } from '@lucide/svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 
@@ -77,6 +79,10 @@
 
 	const categories = getCategoriesContext();
 	const dashboardPath = resolve('/dashboard');
+
+	// Mode/month/year changes are same-route navigations: keep the controls
+	// interactive and skeleton the body, which re-derives entirely from `data`.
+	const reloading = usePendingReload();
 
 	const chartColors = [
 		'var(--chart-1)',
@@ -408,7 +414,21 @@
 		</div>
 	</div>
 
-	{#if selectedMode === 'monthly'}
+	{#if reloading.current}
+		<CardGridSkeleton
+			cards={4}
+			linesPerCard={2}
+			class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4"
+			label="Loading dashboard figures"
+		/>
+		<CardGridSkeleton
+			cards={2}
+			linesPerCard={1}
+			lineClass="h-56"
+			class="mb-6 grid grid-cols-1 gap-4 lg:grid-cols-2"
+			label="Loading dashboard charts"
+		/>
+	{:else if selectedMode === 'monthly'}
 		<!-- KPI Sparkline Row -->
 		<div
 			class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-3 {data.windowCleaningJobCount

--- a/src/routes/(app)/finances/budget/+page.svelte
+++ b/src/routes/(app)/finances/budget/+page.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/state';
 	import type { Budget, ChartData } from '$lib';
 	import AreaChart from '$lib/components/AreaChart.svelte';
+	import CardGridSkeleton from '$lib/components/CardGridSkeleton.svelte';
 	import MonthYearSwitcher from '$lib/components/MonthYearSwitcher.svelte';
 	import PresetBudgetCard from '$lib/components/PresetBudgetCard.svelte';
 	import SummaryRow from '$lib/components/SummaryRow.svelte';
@@ -10,6 +11,7 @@
 	import { getCategoriesContext } from '$lib/contexts';
 	import { months } from '$lib/utils';
 	import { padMonth } from '$lib/utils/dates';
+	import { usePendingReload } from '$lib/utils/pendingNavigation.svelte';
 	import CheckCircleIcon from '@lucide/svelte/icons/check-circle';
 	import HelpCircleIcon from '@lucide/svelte/icons/help-circle';
 	import SlidersHorizontalIcon from '@lucide/svelte/icons/sliders-horizontal';
@@ -73,6 +75,10 @@
 	}
 
 	const categories = getCategoriesContext();
+
+	// A month switch is a same-route navigation. Column 1 (the category list)
+	// stays clickable; only the month-dependent columns skeleton.
+	const reloading = usePendingReload();
 
 	// Sort categories alphabetically
 	let sortedCategories = $derived([...categories()].sort((a, b) => a.name.localeCompare(b.name)));
@@ -351,7 +357,15 @@
 
 		<!-- Column 2: Category Detail -->
 		<div class="lg:col-span-7">
-			{#if selectedCategory}
+			{#if reloading.current}
+				<CardGridSkeleton
+					cards={1}
+					linesPerCard={3}
+					lineClass="h-24"
+					class="flex flex-col gap-4"
+					label="Loading category budget"
+				/>
+			{:else if selectedCategory}
 				<!-- Heading -->
 				<div class="mb-6">
 					<h2 class="text-2xl font-semibold">
@@ -436,56 +450,65 @@
 
 		<!-- Column 3: Total Summary -->
 		<div class="lg:col-span-3">
-			<!-- Budget Status Box -->
-			<div class="bg-card mb-4 rounded-lg border shadow">
-				<div class="relative p-6">
-					<div class="absolute top-4 right-4">
-						{#if allBudgetsSet}
-							<CheckCircleIcon class="h-5 w-5 fill-green-500 text-white" />
-						{:else}
-							<CheckCircleIcon class="h-5 w-5 text-gray-300" />
-						{/if}
-					</div>
-					<div class="flex flex-col items-center justify-center space-y-2">
-						<SlidersHorizontalIcon class="text-muted-foreground h-5 w-5" />
-						<p class="text-lg font-semibold">
-							Set {months.find((m) => m.value === padMonth(selectedMonth.toString()))?.label ||
-								'Monthly'} Budget
-						</p>
-						{#if categoriesWithoutBudget.length > 0}
-							<p class="text-muted-foreground text-sm">
-								There is no budget set for {categoriesWithoutBudget.length}
-								{categoriesWithoutBudget.length === 1 ? 'category' : 'categories'}.
+			{#if reloading.current}
+				<CardGridSkeleton
+					cards={2}
+					linesPerCard={3}
+					class="flex flex-col gap-4"
+					label="Loading budget summary"
+				/>
+			{:else}
+				<!-- Budget Status Box -->
+				<div class="bg-card mb-4 rounded-lg border shadow">
+					<div class="relative p-6">
+						<div class="absolute top-4 right-4">
+							{#if allBudgetsSet}
+								<CheckCircleIcon class="h-5 w-5 fill-green-500 text-white" />
+							{:else}
+								<CheckCircleIcon class="h-5 w-5 text-gray-300" />
+							{/if}
+						</div>
+						<div class="flex flex-col items-center justify-center space-y-2">
+							<SlidersHorizontalIcon class="text-muted-foreground h-5 w-5" />
+							<p class="text-lg font-semibold">
+								Set {months.find((m) => m.value === padMonth(selectedMonth.toString()))?.label ||
+									'Monthly'} Budget
 							</p>
-						{:else}
-							<p class="text-muted-foreground text-sm">All budgets are set!</p>
-						{/if}
+							{#if categoriesWithoutBudget.length > 0}
+								<p class="text-muted-foreground text-sm">
+									There is no budget set for {categoriesWithoutBudget.length}
+									{categoriesWithoutBudget.length === 1 ? 'category' : 'categories'}.
+								</p>
+							{:else}
+								<p class="text-muted-foreground text-sm">All budgets are set!</p>
+							{/if}
+						</div>
 					</div>
 				</div>
-			</div>
 
-			<!-- Spending Overview Box -->
-			<div class="bg-card rounded-lg border shadow">
-				<div class="border-b p-6">
-					<h3 class="text-lg font-semibold">
-						{months.find((m) => m.value === padMonth(selectedMonth.toString()))?.label || 'Monthly'} Spending
-						Overview
-					</h3>
-				</div>
-				<div class="p-6">
-					<div class="space-y-4">
-						<SummaryRow label="Recurring Expenses" amount={totalRecurring} />
-						<SummaryRow label="You Budgeted" amount={totalBudget} />
-						<SummaryRow
-							label="You Expect To Spend"
-							amount={totalRecurring + totalBudget}
-							emphasized={true}
-							bordered={true}
-							muted={false}
-						/>
+				<!-- Spending Overview Box -->
+				<div class="bg-card rounded-lg border shadow">
+					<div class="border-b p-6">
+						<h3 class="text-lg font-semibold">
+							{months.find((m) => m.value === padMonth(selectedMonth.toString()))?.label ||
+								'Monthly'} Spending Overview
+						</h3>
+					</div>
+					<div class="p-6">
+						<div class="space-y-4">
+							<SummaryRow label="Recurring Expenses" amount={totalRecurring} />
+							<SummaryRow label="You Budgeted" amount={totalBudget} />
+							<SummaryRow
+								label="You Expect To Spend"
+								amount={totalRecurring + totalBudget}
+								emphasized={true}
+								bordered={true}
+								muted={false}
+							/>
+						</div>
 					</div>
 				</div>
-			</div>
+			{/if}
 		</div>
 	</div>
 </div>

--- a/src/routes/(app)/finances/income/+page.svelte
+++ b/src/routes/(app)/finances/income/+page.svelte
@@ -81,6 +81,7 @@
 	mainClass="flex flex-col gap-6 lg:grid lg:grid-cols-4"
 	tableColumnClass="lg:col-span-3"
 	summaryColumnClass="lg:col-span-1"
+	skeletonColumns={columns.length}
 >
 	{#snippet headerActions()}
 		<Button size="sm" onclick={() => (openModal = true)}>

--- a/src/routes/(app)/finances/transactions/+page.svelte
+++ b/src/routes/(app)/finances/transactions/+page.svelte
@@ -148,6 +148,8 @@
 	tableColumnClass={data.searchQuery ? '' : 'lg:col-span-3'}
 	summaryColumnClass={data.searchQuery ? '' : 'lg:col-span-1'}
 	showSummary={!data.searchQuery}
+	skeletonColumns={columns.length}
+	skeletonSummaryCards={3}
 >
 	{#snippet topControls()}
 		<div class="relative">

--- a/src/routes/(app)/receipts/business/+page.svelte
+++ b/src/routes/(app)/receipts/business/+page.svelte
@@ -86,6 +86,7 @@
 	mainClass="flex flex-col gap-6 lg:grid lg:grid-cols-4"
 	tableColumnClass="lg:col-span-3"
 	summaryColumnClass="lg:col-span-1"
+	skeletonColumns={columns.length}
 >
 	{#snippet headerActions()}
 		<Button size="sm" onclick={() => (openModal = true)}>

--- a/src/routes/(app)/receipts/fuel/+page.svelte
+++ b/src/routes/(app)/receipts/fuel/+page.svelte
@@ -97,6 +97,7 @@
 	mainClass="flex flex-col gap-6 lg:grid lg:grid-cols-4"
 	tableColumnClass="lg:col-span-3"
 	summaryColumnClass="lg:col-span-1"
+	skeletonColumns={columns.length}
 >
 	{#snippet headerActions()}
 		<Button size="sm" onclick={() => (openModal = true)}>

--- a/src/routes/(app)/window-cleaning/jobs/+page.svelte
+++ b/src/routes/(app)/window-cleaning/jobs/+page.svelte
@@ -2,10 +2,13 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import type { WindowCleaningJob } from '$lib';
+	import CardGridSkeleton from '$lib/components/CardGridSkeleton.svelte';
+	import TableSkeleton from '$lib/components/TableSkeleton.svelte';
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import DataTable from '$lib/components/ui/data-table/data-table.svelte';
 	import YearSwitcher from '$lib/components/YearSwitcher.svelte';
 	import type { windowCleaningJobSchema } from '$lib/formSchemas';
+	import { usePendingReload } from '$lib/utils/pendingNavigation.svelte';
 	import { setContext } from 'svelte';
 	import type { SuperValidated } from 'sveltekit-superforms';
 	import type { z } from 'zod';
@@ -55,6 +58,10 @@
 		style: 'currency',
 		currency: 'CAD'
 	});
+
+	// A year switch is a same-route navigation: keep the heading and switcher
+	// live, and skeleton only the stats and table.
+	const reloading = usePendingReload();
 </script>
 
 <svelte:head>
@@ -73,54 +80,66 @@
 		<YearSwitcher currentYear={selectedYear} {onYearChange} />
 	</div>
 
-	<!-- Stats Row -->
-	<div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
-		<Card>
-			<CardContent class="pt-6">
-				<p class="text-muted-foreground text-sm">Jobs</p>
-				<p class="text-2xl font-bold">{data.jobCount}</p>
-			</CardContent>
-		</Card>
-		<Card>
-			<CardContent class="pt-6">
-				<p class="text-muted-foreground text-sm">Charged</p>
-				<p class="text-2xl font-bold">{currencyFormatter.format(data.totalCharged)}</p>
-			</CardContent>
-		</Card>
-		<Card>
-			<CardContent class="pt-6">
-				<p class="text-muted-foreground text-sm">Tips</p>
-				<p class="text-2xl font-bold">{currencyFormatter.format(data.totalTips)}</p>
-			</CardContent>
-		</Card>
-		<Card>
-			<CardContent class="pt-6">
-				<p class="text-muted-foreground text-sm">Total Earned</p>
-				<p class="text-2xl font-bold text-green-600 dark:text-green-400">
-					{currencyFormatter.format(data.totalEarned)}
-				</p>
-				{#if data.earnedLastYear > 0}
-					{@const diff = data.totalEarned - data.earnedLastYear}
-					{@const pct = Math.round(Math.abs(diff / data.earnedLastYear) * 100)}
-					<p
-						class="mt-1 text-xs {diff >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-500'}"
-					>
-						{diff >= 0 ? '▲' : '▼'}
-						{pct}% vs {selectedYear - 1} ({currencyFormatter.format(data.earnedLastYear)})
-					</p>
-				{/if}
-			</CardContent>
-		</Card>
-	</div>
-
-	<!-- Jobs Table -->
-	{#if data.jobs.length > 0}
-		<DataTable {columns} data={data.jobs} />
+	{#if reloading.current}
+		<CardGridSkeleton
+			cards={4}
+			linesPerCard={1}
+			class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4"
+			label="Loading job totals"
+		/>
+		<TableSkeleton rows={8} columns={columns.length} />
 	{:else}
-		<Card>
-			<CardContent class="py-12 text-center">
-				<p class="text-muted-foreground">No jobs found for this year.</p>
-			</CardContent>
-		</Card>
+		<!-- Stats Row -->
+		<div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+			<Card>
+				<CardContent class="pt-6">
+					<p class="text-muted-foreground text-sm">Jobs</p>
+					<p class="text-2xl font-bold">{data.jobCount}</p>
+				</CardContent>
+			</Card>
+			<Card>
+				<CardContent class="pt-6">
+					<p class="text-muted-foreground text-sm">Charged</p>
+					<p class="text-2xl font-bold">{currencyFormatter.format(data.totalCharged)}</p>
+				</CardContent>
+			</Card>
+			<Card>
+				<CardContent class="pt-6">
+					<p class="text-muted-foreground text-sm">Tips</p>
+					<p class="text-2xl font-bold">{currencyFormatter.format(data.totalTips)}</p>
+				</CardContent>
+			</Card>
+			<Card>
+				<CardContent class="pt-6">
+					<p class="text-muted-foreground text-sm">Total Earned</p>
+					<p class="text-2xl font-bold text-green-600 dark:text-green-400">
+						{currencyFormatter.format(data.totalEarned)}
+					</p>
+					{#if data.earnedLastYear > 0}
+						{@const diff = data.totalEarned - data.earnedLastYear}
+						{@const pct = Math.round(Math.abs(diff / data.earnedLastYear) * 100)}
+						<p
+							class="mt-1 text-xs {diff >= 0
+								? 'text-green-600 dark:text-green-400'
+								: 'text-red-500'}"
+						>
+							{diff >= 0 ? '▲' : '▼'}
+							{pct}% vs {selectedYear - 1} ({currencyFormatter.format(data.earnedLastYear)})
+						</p>
+					{/if}
+				</CardContent>
+			</Card>
+		</div>
+
+		<!-- Jobs Table -->
+		{#if data.jobs.length > 0}
+			<DataTable {columns} data={data.jobs} />
+		{:else}
+			<Card>
+				<CardContent class="py-12 text-center">
+					<p class="text-muted-foreground">No jobs found for this year.</p>
+				</CardContent>
+			</Card>
+		{/if}
 	{/if}
 </div>


### PR DESCRIPTION
Closes #299.

## Problem

`src/routes/(app)/+layout.svelte` gated the entire page body on `navigating.to`:

```svelte
{#if navigating.to}
	<LoadingSpinner fullScreen={true} size="lg" />
{:else}
	{@render children()}
{/if}
```

Every month/year switch in the app is a `goto()` with new search params — a real SvelteKit navigation. So switching June → July on `finances/income` unmounted the whole page (table, summary cards, headings, month switcher, open modals, the transactions search box) and replaced it with a centred spinner, when only the data had changed.

It also made per-route skeletons structurally unreachable: any page-level `{#if loading}` driven by `navigating` cannot paint, because the layout stops rendering `children()` at exactly the moment that condition becomes true. That is why #298 found every skeleton branch in the app dead and deleted `TableSkeleton.svelte` along with them.

## Approach

The layout gate now fires only for **cross-route** navigation. Same-route navigations keep the page frame mounted and skeleton only the regions fed by `data`.

- **`src/lib/utils/navigation.ts`** — `classifyNavigation(toRouteId, currentRouteId)` → `idle | same-route | cross-route`. Kept free of `$app/state` imports so it unit-tests in the repo's node-only Vitest setup. Call sites pass `navigating.to?.route.id` directly: `undefined` means no navigation, `null` means the target is not a SvelteKit-owned route (correctly cross-route).
- **`src/lib/utils/pendingNavigation.svelte.ts`** — `usePendingReload()`, true only once a same-route reload has run for **150ms**. Local SQLite loads are frequently well under that, and a skeleton that flashes for a few frames reads as a glitch; below the threshold the previous content simply stays put.

## Skeletons

No shadcn-svelte install was needed — `skeleton` was already present at `src/lib/components/ui/skeleton/`. Both components build on it.

- **`TableSkeleton.svelte`** — restored from `d605bb0^` with three fixes: `Array.from({ length: n })` instead of sparse `Array(n)`; `w-18` / `w-30` dropped (not on Tailwind's default scale, so they emitted nothing in v4); `role="status"` + `sr-only` label, since SvelteKit's built-in announcer only fires on *completed* navigation.
- **`CardGridSkeleton.svelte`** — new, generic. Reuses the same `overflow-hidden rounded-lg border shadow` frame as the real cards so nothing shifts on swap.

## Wiring

`MonthlyTablePageShell.svelte` covers `finances/income`, `finances/transactions`, `receipts/business` and `receipts/fuel` in a single edit — those four only pass `skeletonColumns={columns.length}`. The month switcher, "Jump to Month" select, title and header actions stay mounted and interactive throughout.

`finances/budget`, `dashboard` and `window-cleaning/jobs` use their own bespoke switchers rather than the shell, so each is wired individually.

Not touched: `admin/*`, `savings/*`, `setup/*` — none navigate within their own route, so a same-route skeleton would never fire there.

## Fixes that fall out

- `goto(..., { keepFocus: true })` now actually works on the month chevron — the button is no longer destroyed mid-navigation.
- The transactions search input survives its own debounced navigations, keeping focus and value.
- `LoadingSpinner`'s hard-coded `border-black` → `border-foreground`; it was near-invisible in dark mode.

## Judgement call worth reviewing

On `finances/budget`, column 1 (the category list) stays live and clickable while columns 2–3 skeleton. Its per-category check/help icons read `data.budget`, so they are briefly stale during a month switch — traded for keeping category selection usable.

## Verification

- `svelte-check`: 0 errors. `npm run lint`: exit 0. `npm run build`: exit 0.
- 310/310 tests pass, including 19 new ones across `classifyNavigation`, `TableSkeleton` and `CardGridSkeleton`.
- Svelte MCP autofixer reports no issues on either new component.

Route-level wiring is manual-only — `vite.config.ts` excludes `src/routes/**` from coverage and the suite is SSR-string-only (no jsdom). Reviewer checks:

1. `/finances/income` → month chevron: frame and controls stay put; table + summary swap to skeletons; no full-screen spinner, no layout shift.
2. Step through months quickly — on a warm local DB most loads finish under 150ms and should show **no** skeleton at all.
3. Sidebar → Dashboard / Budgets / Receipts: full-screen spinner still appears, unchanged.
4. Tab to the month chevron and press Enter repeatedly — focus persists (currently broken on `main`).
5. Transactions search: type continuously, input keeps focus and value; summary column still hides under `showSummary={!data.searchQuery}`.
6. `/finances/budget`, `/dashboard` (both modes), `/window-cleaning/jobs`.

To actually see the skeletons on a fast local DB, throttle in DevTools or temporarily raise `SKELETON_DELAY_MS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)