### PR TITLE
Enable typescript/no-non-null-assertion to block `locals.user!` regressions (#301)

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -25,6 +25,15 @@ export default defineConfig({
 		typeAware: true,
 		typeCheck: true
 	},
+	overrides: [
+		{
+			// Non-null assertions are legitimate in test fixtures, where the setup guarantees the value.
+			files: ['**/*.test.ts'],
+			rules: {
+				'typescript/no-non-null-assertion': 'off'
+			}
+		}
+	],
 	plugins: ['eslint', 'typescript', 'oxc', 'vitest', 'unicorn'],
 	rules: {
 		'no-unused-vars': [
@@ -33,6 +42,7 @@ export default defineConfig({
 				argsIgnorePattern: '^_',
 				varsIgnorePattern: '^_'
 			}
-		]
+		],
+		'typescript/no-non-null-assertion': 'error'
 	}
 });

--- a/src/routes/(app)/finances/budget/+page.server.ts
+++ b/src/routes/(app)/finances/budget/+page.server.ts
@@ -159,7 +159,11 @@ export const actions = {
 			);
 		}
 
-		const budgetId = form.data.id!;
+		const budgetId = form.data.id;
+
+		if (!budgetId) {
+			return message(form, { type: 'error', text: 'Budget ID is required.' }, { status: 400 });
+		}
 
 		try {
 			await getDb()

--- a/src/routes/(app)/finances/budget/+page.svelte
+++ b/src/routes/(app)/finances/budget/+page.svelte
@@ -25,7 +25,7 @@
 
 	// Initialize superform
 	const formInstance = $derived(
-		superForm(data.form!, {
+		superForm(data.form, {
 			resetForm: false,
 			onUpdate: ({ form }) => {
 				if (form.valid) {

--- a/src/routes/(app)/window-cleaning/+page.svelte
+++ b/src/routes/(app)/window-cleaning/+page.svelte
@@ -59,9 +59,12 @@
 	});
 
 	let selectedCustomerJobs = $derived.by(() => {
-		if (!selectedCustomer) return [];
-		const c = data.customers.find((c) => c.id === selectedCustomer!.id);
-		return c ? [...c.jobs].toSorted((a, b) => b.jobDate.localeCompare(a.jobDate)) : [];
+		const selected = selectedCustomer;
+		if (!selected) return [];
+		const customer = data.customers.find((c) => c.id === selected.id);
+		return customer
+			? [...customer.jobs].toSorted((a, b) => b.jobDate.localeCompare(a.jobDate))
+			: [];
 	});
 
 	function handleLogJob() {


### PR DESCRIPTION
Closes #301.

## Why

PR #300 removed the two `locals.user!` assertions from load functions and added a typed `requireUser` guard, but nothing stopped the pattern from coming back. This adds the guardrail, in the same spirit as the existing `check:no-explicit-any`, `check:redirect-throws` and `check:dead-exports` static checks.

No new tooling is needed: the `typescript` plugin is already enabled, and `no-non-null-assertion` just sits in the `style` category, which the config turns off wholesale. Naming the rule explicitly in `rules` switches it on without dragging in the rest of `style`.

## Test fixtures are exempt

An `overrides` entry disables the rule for `**/*.test.ts`. The 15 assertions in `src/lib/server/db/queries/*.test.ts` are all cases where the surrounding setup guarantees the value, and rewriting them would add noise without catching anything. All test files in the repo use `.test.ts`, so one pattern covers it.

## The three real sites

| File | Was | Now |
|---|---|---|
| `budget/+page.svelte:28` | `data.form!` | The load returns `form` unconditionally, so `PageData` already types it non-optional — the `!` was a no-op. Deleted. |
| `budget/+page.server.ts:162` | `form.data.id!` | A genuine hole, not a type nag — see below. Now returns a 400 `message(...)`. |
| `window-cleaning/+page.svelte:63` | `selectedCustomer!.id` | TS narrowing limitation inside a `$derived.by` closure. Hoisted to a local const. |

On the middle one: `budgetSchema` marks `id` optional because the same schema backs `create`. An update posted without an id would have run `where(eq(budget.id, undefined))` — the `!` was suppressing a real case. The new guard matches the validation failure directly above it, and stays on `message(...)` rather than `fail(...)` so the superForm client still gets the form back.

On the last one: the closure could in principle run after the null check, which is why TS drops the narrowing. Hoisting to `const selected` carries it in. The result binding is renamed `c` → `customer` while there, as it was shadowing the `.find()` parameter.

## Verification

- `npm run lint` — clean
- `npm run check` — 8158 files, 0 errors, 0 warnings
- `npm run test` — 34 files, 310 tests passed
- `npm run fmt:check` — clean

The guardrail was probed in both directions rather than assumed: a temporary `x!.length` in a non-test file fails `oxlint` with exit 1, and the identical line in a `*.test.ts` file passes.

Not done: manual browser smoke checks of the budget save flow and the window-cleaning customer sheet. The static checks cover type-level correctness, but the `update` action's DB write path hasn't been exercised at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)