### PR TITLE
Align /auth action failure response contract

### DIFF
--- a/docs/ERROR_HANDLING_POLICY.md
+++ b/docs/ERROR_HANDLING_POLICY.md
@@ -78,26 +78,58 @@ export const load: PageServerLoad = async ({ url }) => {
 
 ## Policy: Actions
 
-Actions already have consistent error handling via `createCrudActions` helper or explicit try/catch blocks. The pattern is:
+### Response contract
+
+A form action returns exactly one of three things. There is no fourth shape — in particular, never a
+bare `fail(...)` and never an ad-hoc `{ success: true }`.
+
+| Outcome                            | Response                                             | HTTP    |
+| ---------------------------------- | ---------------------------------------------------- | ------- |
+| Success, navigate away             | `throw redirect(302, '/somewhere')`                  | 302     |
+| Success, stay on page              | `message(form, { type: 'success', text })`           | 200     |
+| Failure (validation **or** server) | `message(form, { type: 'error', text }, { status })` | 4xx/5xx |
+
+Superforms converts a `message(...)` with a 4xx/5xx status into `fail(status, { form })`, so the
+failure case still carries field-level errors — it just also carries a banner. Every failure
+therefore has a renderable `App.Superforms.Message` (declared in `src/app.d.ts`), and pages only ever
+read `$message` and `$errors`. No page has to branch on which shape the server happened to send.
+
+### Implementations
+
+Both halves live in `src/lib/server/actions/auth-form-handler.ts`:
 
 ```typescript
-try {
-	// Perform action
-	await someAction();
-	logger.info('Action completed successfully', { context });
-	return { success: true, form };
-} catch (error) {
-	logger.error('Action failed:', error);
-	return message(
-		form,
-		{
-			type: 'error',
-			text: 'Friendly error message for user'
-		},
-		{ status: 500 }
-	);
+// Validation failure
+if (!form.valid) {
+	return invalidAuthForm(form);
 }
+
+// Server failure: rethrows redirects, logs, maps the Better Auth error to a
+// friendly message, and returns the failure banner.
+return handleAuthFormAction(
+	form,
+	async () => {
+		await auth.api.signInEmail({ body: { ... }, headers: request.headers });
+		throw redirect(302, '/dashboard');
+	},
+	{
+		loggerContext: 'Sign-in failed',
+		fallbackMessage: 'An error occurred during sign-in. Please try again.'
+	}
+);
 ```
+
+`handleAuthFormAction` defaults to status 400; pass `status` only to override it. Pass
+`errorType: 'success'` where a failure must stay indistinguishable from a success (see
+`src/routes/auth/forgot-password/+page.server.ts`, which hides whether an account exists).
+
+### Migration status
+
+All `/auth` actions follow this contract. CRUD actions built on `createCrudActions`
+(`src/lib/server/actions/crud-helpers.ts`) are consistent within themselves but not yet aligned to
+the table above — `src/routes/(app)/admin/users/+page.server.ts` and
+`src/routes/(app)/finances/budget/+page.server.ts` still return `{ success: true }`. Adopt this
+contract when touching them.
 
 ## Exceptions
 
@@ -124,5 +156,6 @@ Components should check for `loadError` and display it prominently:
 
 ## References
 
-- Example implementation: `src/routes/(app)/admin/users/+page.server.ts`
-- Structure review: `docs/structure-review/2026-07-27-review.md` (Finding: Error Handling → Finding 1)
+- Example load implementation: `src/routes/(app)/admin/users/+page.server.ts`
+- Example action implementation: `src/routes/auth/sign-in/+page.server.ts`
+- Structure review: `docs/structure-review/2026-07-27-review.md` (Error Handling → Findings 1 and 2)

--- a/src/lib/server/actions/auth-form-handler.test.ts
+++ b/src/lib/server/actions/auth-form-handler.test.ts
@@ -6,10 +6,50 @@ import { zod4 } from 'sveltekit-superforms/adapters';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
-import { handleAuthFormAction } from './auth-form-handler';
+import { handleAuthFormAction, invalidAuthForm } from './auth-form-handler';
 
 const testSchema = z.object({
 	email: z.string().email()
+});
+
+describe('invalidAuthForm', () => {
+	it('returns a 400 form failure carrying a renderable error banner', async () => {
+		const form = await superValidate(zod4(testSchema));
+
+		expect(invalidAuthForm(form)).toMatchObject({
+			status: 400,
+			data: {
+				form: expect.objectContaining({
+					valid: false,
+					message: { type: 'error', text: 'Please correct the errors in the form.' }
+				})
+			}
+		});
+	});
+
+	it('honours a custom message text', async () => {
+		const form = await superValidate(zod4(testSchema));
+
+		expect(invalidAuthForm(form, 'That reset link is no longer valid.')).toMatchObject({
+			data: {
+				form: expect.objectContaining({
+					message: { type: 'error', text: 'That reset link is no longer valid.' }
+				})
+			}
+		});
+	});
+
+	it('produces a payload the auth banner can actually render', async () => {
+		const form = await superValidate(zod4(testSchema));
+		const result = invalidAuthForm(form) as unknown as {
+			data: { form: { message: App.Superforms.Message } };
+		};
+
+		const html = render(AuthFormMessage, { props: { message: result.data.form.message } }).body;
+
+		expect(html).toContain('Please correct the errors in the form.');
+		expect(html).toContain('bg-red-50/80');
+	});
 });
 
 describe('handleAuthFormAction', () => {

--- a/src/lib/server/actions/auth-form-handler.ts
+++ b/src/lib/server/actions/auth-form-handler.ts
@@ -18,6 +18,19 @@ interface AuthFormActionOptions {
 	status?: MessageOptions['status'];
 }
 
+/**
+ * The single validation-failure response for auth actions. Superforms turns a
+ * `message(...)` with a 4xx status into `fail(status, { form })`, so the page
+ * gets field errors *and* a banner from one call — no route needs a bare
+ * `fail(...)` and no page has to branch on which shape it received.
+ */
+export function invalidAuthForm<TForm extends Record<string, unknown>>(
+	form: SuperValidated<TForm>,
+	text = 'Please correct the errors in the form.'
+) {
+	return message(form, { type: 'error', text }, { status: 400 });
+}
+
 export async function handleAuthFormAction<TForm extends Record<string, unknown>>(
 	form: SuperValidated<TForm>,
 	action: () => Promise<unknown>,

--- a/src/routes/auth/forgot-password/+page.server.ts
+++ b/src/routes/auth/forgot-password/+page.server.ts
@@ -1,8 +1,8 @@
 import { BETTER_AUTH_BASE_URL } from '$app/env/private';
-import { handleAuthFormAction } from '$lib/server/actions/auth-form-handler';
+import { handleAuthFormAction, invalidAuthForm } from '$lib/server/actions/auth-form-handler';
 import { formMessageFromUrl } from '$lib/server/actions/form-message';
 import { auth } from '$lib/server/auth';
-import { fail, redirect } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import { message, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 import { z } from 'zod';
@@ -34,9 +34,7 @@ export const actions: Actions = {
 		const form = await superValidate(request, zod4(forgotSchema));
 
 		if (!form.valid) {
-			return fail(400, {
-				form
-			});
+			return invalidAuthForm(form);
 		}
 
 		return handleAuthFormAction(

--- a/src/routes/auth/register/+page.server.ts
+++ b/src/routes/auth/register/+page.server.ts
@@ -1,9 +1,9 @@
 import { registerSchema } from '$lib/formSchemas';
-import { handleAuthFormAction } from '$lib/server/actions/auth-form-handler';
+import { handleAuthFormAction, invalidAuthForm } from '$lib/server/actions/auth-form-handler';
 import { formMessageFromUrl } from '$lib/server/actions/form-message';
 import { auth } from '$lib/server/auth';
 import { redirect } from '@sveltejs/kit';
-import { message, superValidate } from 'sveltekit-superforms';
+import { superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 
 import type { Actions, PageServerLoad } from './$types';
@@ -28,11 +28,7 @@ export const actions: Actions = {
 		const form = await superValidate(request, zod4(registerSchema));
 
 		if (!form.valid) {
-			return message(
-				form,
-				{ type: 'error', text: 'Please correct the errors in the form.' },
-				{ status: 400 }
-			);
+			return invalidAuthForm(form);
 		}
 
 		return handleAuthFormAction(
@@ -52,8 +48,7 @@ export const actions: Actions = {
 			},
 			{
 				loggerContext: 'Registration failed',
-				fallbackMessage: 'Registration failed. Please try again.',
-				status: 400
+				fallbackMessage: 'Registration failed. Please try again.'
 			}
 		);
 	}

--- a/src/routes/auth/reset-password/+page.server.ts
+++ b/src/routes/auth/reset-password/+page.server.ts
@@ -1,7 +1,7 @@
-import { handleAuthFormAction } from '$lib/server/actions/auth-form-handler';
+import { handleAuthFormAction, invalidAuthForm } from '$lib/server/actions/auth-form-handler';
 import { auth } from '$lib/server/auth';
 import { redirect } from '@sveltejs/kit';
-import { message, superValidate } from 'sveltekit-superforms';
+import { superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 import { z } from 'zod';
 
@@ -53,11 +53,7 @@ export const actions: Actions = {
 		const form = await superValidate(request, zod4(resetPasswordSchema));
 
 		if (!form.data.token || !form.valid) {
-			return message(
-				form,
-				{ type: 'error', text: 'Please correct the errors in the form.' },
-				{ status: 400 }
-			);
+			return invalidAuthForm(form);
 		}
 
 		return handleAuthFormAction(
@@ -77,8 +73,7 @@ export const actions: Actions = {
 			},
 			{
 				loggerContext: 'Password reset failed',
-				fallbackMessage: 'Failed to reset password. Please try again.',
-				status: 400
+				fallbackMessage: 'Failed to reset password. Please try again.'
 			}
 		);
 	}

--- a/src/routes/auth/sign-in/+page.server.ts
+++ b/src/routes/auth/sign-in/+page.server.ts
@@ -1,9 +1,9 @@
 import { signInSchema } from '$lib/formSchemas';
-import { handleAuthFormAction } from '$lib/server/actions/auth-form-handler';
+import { handleAuthFormAction, invalidAuthForm } from '$lib/server/actions/auth-form-handler';
 import { formMessageFromUrl } from '$lib/server/actions/form-message';
 import { auth } from '$lib/server/auth';
 import { redirect } from '@sveltejs/kit';
-import { message, superValidate } from 'sveltekit-superforms';
+import { superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 
 import type { Actions, PageServerLoad } from './$types';
@@ -29,11 +29,7 @@ export const actions: Actions = {
 		const form = await superValidate(request, zod4(signInSchema));
 
 		if (!form.valid) {
-			return message(
-				form,
-				{ type: 'error', text: 'Please correct the errors in the form.' },
-				{ status: 400 }
-			);
+			return invalidAuthForm(form);
 		}
 
 		return handleAuthFormAction(


### PR DESCRIPTION
Closes #282

## Problem

Action failures used mixed response shapes. Within `/auth`, three routes returned a superforms `message(...)` with a 400 status, while `forgot-password` returned a bare `fail(400, { form })` — field errors, but no banner. Pages had to cope with either shape.

## Contract

A form action now returns exactly one of three things:

| Outcome | Response | HTTP |
| --- | --- | --- |
| Success, navigate away | `throw redirect(302, ...)` | 302 |
| Success, stay on page | `message(form, { type: 'success', text })` | 200 |
| Failure (validation **or** server) | `message(form, { type: 'error', text }, { status })` | 4xx/5xx |

Superforms turns a 4xx `message(...)` into `fail(status, { form })`, so failures keep field-level errors and gain a renderable `App.Superforms.Message`. Pages only read `$message` + `$errors` — no branching on shape.

## Changes

- `invalidAuthForm()` added next to `handleAuthFormAction` in `src/lib/server/actions/auth-form-handler.ts`, so both halves of the contract live in one module
- sign-in, register, reset-password, forgot-password all use it for the invalid-form branch
- Dropped the redundant `status: 400` from register/reset-password — already the handler default
- `docs/ERROR_HANDLING_POLICY.md`: documented the contract, replacing the old `{ success: true }` action example that was itself the anti-pattern this issue is about
- Three new unit tests for `invalidAuthForm`, including a render assertion through `AuthFormMessage`

## Behaviour change

One, intentional: a validation failure on `/auth/forgot-password` now shows the red banner alongside field errors, matching the other three routes. It is a pure form-validation message and reveals nothing about account existence — the `errorType: 'success'` enumeration protection on that route's server-failure path is untouched, and its success response is byte-identical.

## Verification

`npm run check`, `npm run lint`, `npm run fmt:check` clean; 313/313 tests pass.

Exercised against `npm run dev` by POSTing to each action:
- invalid submissions on all four routes → `{"type":"failure","status":400}` carrying both `errors` and `message: {type:'error', ...}`
- `/auth/reset-password` without a token → same 400 shape as before
- `/auth/forgot-password` with a well-formed unknown email → unchanged `{"type":"success","status":200}` with the green "If an account exists…" message

## Out of scope

`src/routes/(app)/admin/users/+page.server.ts` and `src/routes/(app)/finances/budget/+page.server.ts` still return `{ success: true }`. Tracked in a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)