### PR TITLE
Align action response contract in admin/users and finances/budget (#305)

### DIFF
--- a/docs/ERROR_HANDLING_POLICY.md
+++ b/docs/ERROR_HANDLING_POLICY.md
@@ -123,19 +123,51 @@ return handleAuthFormAction(
 `errorType: 'success'` where a failure must stay indistinguishable from a success (see
 `src/routes/auth/forgot-password/+page.server.ts`, which hides whether an account exists).
 
+### Reading the response on the client
+
+Pages hold a `superForm` instance and read `$message` / `$errors`. Inside the `onUpdate` callback,
+read `form.message` off the callback argument — **not** the `$message` store. `clearOnSubmit` defaults
+to `'message'`, so superforms blanks the store at submit time and only repopulates it after `onUpdate`
+has run; a `$message` read inside `onUpdate` is always `undefined`. See
+`src/routes/(app)/profile/+page.svelte` for the correct pattern.
+
+Note also that `message(form, ..., { status >= 400 })` sets `form.valid = false`, so `form.valid` is a
+usable success check — but prefer `form.message?.type === 'success'`, which is explicit.
+
+Two components submit with plain `use:enhance` from `$app/forms` rather than a `superForm` instance,
+because they render no fields of their own: `ConfirmModal` and `PresetBudgetCard`. They read the
+banner out of the raw `ActionResult` via `actionMessage()` in `src/lib/utils/actionMessage.ts`, which
+is the only place that unwraps a result by hand.
+
 ### Migration status
 
-All `/auth` actions follow this contract. CRUD actions built on `createCrudActions`
-(`src/lib/server/actions/crud-helpers.ts`) are consistent within themselves but not yet aligned to
-the table above — `src/routes/(app)/admin/users/+page.server.ts` and
-`src/routes/(app)/finances/budget/+page.server.ts` still return `{ success: true }`. Adopt this
-contract when touching them.
+All `/auth` actions follow this contract, as do
+`src/routes/(app)/admin/users/+page.server.ts` and `src/routes/(app)/finances/budget/+page.server.ts`.
+
+Still to migrate:
+
+- `src/lib/server/actions/crud-helpers.ts` (`createCrudActions`) — consistent within itself, but
+  returns `{ success: true, create/update/delete: true }` and bare `fail(...)`. Fans out to 8 routes.
+- `src/routes/(app)/admin/archived-goals/+page.server.ts`
+- `src/routes/(app)/admin/deleted-customers/+page.server.ts`
+- `src/routes/(app)/window-cleaning/+page.server.ts` (`deleteCustomer`)
+- `src/lib/server/actions/window-cleaning-jobs.ts` (`deleteJob`)
+
+Adopt this contract when touching them. `actionMessage()` keeps a fallback for the legacy
+`fail(status, { error })` shape so these routes still surface a message in the meantime; that fallback
+can go once they are migrated.
 
 ## Exceptions
 
 - **Auth redirects**: `throw redirect(...)` is intentional control flow, not an error case
 - **Validation failures**: Already handled by superforms/zod validation
 - **Intentional error throws**: When using `error(404, 'Not found')` is appropriate
+- **`requireAuth`'s 401**: `src/lib/server/actions/auth-guard.ts` returns `fail(401, { error })`
+  because it runs before any `superValidate` and so has no form to carry a message. It is
+  defence-in-depth — `src/routes/(app)/+layout.server.ts` already redirects unauthenticated users, so
+  this path is not normally reachable. Contrast `adminAuthFailure`
+  (`src/lib/server/actions/admin-guard.ts`), which takes an optional `form` and returns
+  `message(form, ...)` when given one.
 
 ## Frontend Integration
 

--- a/src/lib/components/ConfirmModal.svelte
+++ b/src/lib/components/ConfirmModal.svelte
@@ -2,6 +2,7 @@
 	import { enhance } from '$app/forms';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import { actionMessage } from '$lib/utils/actionMessage';
 	import { toast } from 'svelte-sonner';
 
 	interface Props {
@@ -31,13 +32,12 @@
 				open = false;
 
 				return async ({ result, update }) => {
-					if (result.type === 'success') {
-						toast.success(`${title} successful!`);
-					} else if (result.type === 'failure' && result.data?.error) {
-						toast.error((result.data.error as string) || `${title} failed!`);
-					} else {
-						toast.error(`${title} failed!`);
-					}
+					const { type, text } = actionMessage(result, {
+						success: `${title} successful!`,
+						error: `${title} failed!`
+					});
+
+					toast[type](text);
 
 					await update();
 				};

--- a/src/lib/components/PresetBudgetCard.svelte
+++ b/src/lib/components/PresetBudgetCard.svelte
@@ -2,11 +2,14 @@
 	import { enhance as enhanceAction } from '$app/forms';
 	import { Input } from '$lib/components/ui/input';
 	import { formatCurrency } from '$lib/utils';
+	import { actionMessage } from '$lib/utils/actionMessage';
 	import { padMonth } from '$lib/utils/dates';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import CheckCircleIcon from '@lucide/svelte/icons/check-circle';
 	import PencilIcon from '@lucide/svelte/icons/pencil';
 	import XIcon from '@lucide/svelte/icons/x';
+	import type { SubmitFunction } from '@sveltejs/kit';
+	import { toast } from 'svelte-sonner';
 
 	interface Props {
 		title: string;
@@ -23,6 +26,7 @@
 		onSelect: () => void;
 		onEdit?: () => void;
 		onCancel?: () => void;
+		onSaved?: () => void;
 	}
 
 	let {
@@ -39,8 +43,29 @@
 		categoryId,
 		onSelect,
 		onEdit,
-		onCancel
+		onCancel,
+		onSaved
 	}: Props = $props();
+
+	// These cards render no form fields of their own (everything is hidden inputs), so they submit
+	// with plain enhance and read the server's banner out of the result rather than holding a
+	// superForm instance. Shapes come from docs/ERROR_HANDLING_POLICY.md.
+	const enhanceBudget: SubmitFunction =
+		() =>
+		async ({ result, update }) => {
+			const { type, text } = actionMessage(result, {
+				success: 'Budget saved successfully',
+				error: 'Failed to save budget.'
+			});
+
+			if (type === 'success') {
+				onSaved?.();
+			}
+
+			toast[type](text);
+
+			await update();
+		};
 </script>
 
 {#if isCustom}
@@ -71,7 +96,7 @@
 				<form
 					method="POST"
 					action={budgetId ? '?/update' : '?/create'}
-					use:enhanceAction
+					use:enhanceAction={enhanceBudget}
 					class="flex flex-col items-center gap-2"
 				>
 					{#if budgetId}
@@ -128,7 +153,7 @@
 	<form
 		method="POST"
 		action={budgetId ? '?/update' : '?/create'}
-		use:enhanceAction
+		use:enhanceAction={enhanceBudget}
 		class="relative"
 	>
 		{#if budgetId}

--- a/src/lib/formSchemas/auth.ts
+++ b/src/lib/formSchemas/auth.ts
@@ -49,3 +49,10 @@ export const banUserSchema = z.object({
 	userId: z.string().min(1, 'User ID is required'),
 	banReason: z.string().max(500, 'Ban reason must be at most 500 characters')
 });
+
+// The admin actions driven by ConfirmModal (unban, revoke sessions, delete) post a single
+// `id` field. They validate against this so their failures can carry a message, per
+// docs/ERROR_HANDLING_POLICY.md.
+export const userIdSchema = z.object({
+	id: z.string().min(1, 'User ID is required')
+});

--- a/src/lib/formSchemas/form-schemas.test.ts
+++ b/src/lib/formSchemas/form-schemas.test.ts
@@ -14,6 +14,7 @@ import {
 	signInSchema,
 	transactionSchema,
 	unArchiveSchema,
+	userIdSchema,
 	windowCleaningCustomerSchema,
 	windowCleaningJobSchema
 } from './index';
@@ -182,6 +183,12 @@ describe('form schemas', () => {
 
 		expect(banUserSchema.safeParse({ userId: 'user-1', banReason: 'spam' }).success).toBe(true);
 		expect(banUserSchema.safeParse({ userId: '', banReason: 'spam' }).success).toBe(false);
+	});
+
+	it('validates userIdSchema requires a non-empty id', () => {
+		expect(userIdSchema.safeParse({ id: 'user-1' }).success).toBe(true);
+		expect(userIdSchema.safeParse({ id: '' }).success).toBe(false);
+		expect(userIdSchema.safeParse({}).success).toBe(false);
 	});
 
 	it('validates windowCleaningCustomerSchema required fields and lengths', () => {

--- a/src/lib/formSchemas/index.ts
+++ b/src/lib/formSchemas/index.ts
@@ -5,7 +5,8 @@ export {
 	setPasswordSchema,
 	setUserRoleSchema,
 	signInSchema,
-	updateProfileSchema
+	updateProfileSchema,
+	userIdSchema
 } from './auth';
 export { budgetSchema } from './budget';
 export { categorySchema } from './categories';

--- a/src/lib/server/actions/admin-guard.ts
+++ b/src/lib/server/actions/admin-guard.ts
@@ -1,14 +1,28 @@
 import { fail } from '@sveltejs/kit';
+import { message, type SuperValidated } from 'sveltekit-superforms';
 
 import { requireAdmin } from '../auth';
 
-export function adminAuthFailure(locals: App.Locals) {
+/**
+ * Returns null when the caller is an admin, otherwise the failure response to return from the action.
+ *
+ * Pass `form` to get the contract-compliant shape from `docs/ERROR_HANDLING_POLICY.md`
+ * (`message(form, { type: 'error' }, { status })`), so the page can render the reason from `$message`.
+ * Callers that have not yet been migrated may omit it and keep the older `fail(status, { error })`.
+ */
+export function adminAuthFailure<T extends Record<string, unknown>>(
+	locals: App.Locals,
+	form?: SuperValidated<T>
+) {
 	try {
 		requireAdmin(locals);
 		return null;
 	} catch {
-		return fail(locals.user ? 403 : 401, {
-			error: locals.user ? 'Forbidden' : 'Unauthorized'
-		});
+		const status = locals.user ? 403 : 401;
+		const text = locals.user ? 'Forbidden' : 'Unauthorized';
+
+		return form
+			? message(form, { type: 'error', text }, { status })
+			: fail(status, { error: text });
 	}
 }

--- a/src/lib/utils/actionMessage.test.ts
+++ b/src/lib/utils/actionMessage.test.ts
@@ -1,0 +1,87 @@
+import type { ActionResult } from '@sveltejs/kit';
+import { describe, expect, it } from 'vitest';
+
+import { actionMessage } from './actionMessage';
+
+const fallbacks = { success: 'Fallback success', error: 'Fallback error' };
+
+describe('actionMessage', () => {
+	it('returns the success message carried by the form', () => {
+		const result: ActionResult = {
+			type: 'success',
+			status: 200,
+			data: { form: { message: { type: 'success', text: 'Budget saved successfully' } } }
+		};
+
+		expect(actionMessage(result, fallbacks)).toEqual({
+			type: 'success',
+			text: 'Budget saved successfully'
+		});
+	});
+
+	it('returns the error message carried by the form', () => {
+		const result: ActionResult = {
+			type: 'failure',
+			status: 500,
+			data: { form: { message: { type: 'error', text: 'Failed to set user role' } } }
+		};
+
+		expect(actionMessage(result, fallbacks)).toEqual({
+			type: 'error',
+			text: 'Failed to set user role'
+		});
+	});
+
+	it('falls back to a legacy data.error string on failure', () => {
+		const result: ActionResult = {
+			type: 'failure',
+			status: 400,
+			data: { error: 'Cannot delete goal. Please delete all 2 contribution(s) first.' }
+		};
+
+		expect(actionMessage(result, fallbacks)).toEqual({
+			type: 'error',
+			text: 'Cannot delete goal. Please delete all 2 contribution(s) first.'
+		});
+	});
+
+	it('uses the error fallback when a failure carries nothing usable', () => {
+		const result: ActionResult = { type: 'failure', status: 400, data: { hasId: false } };
+
+		expect(actionMessage(result, fallbacks)).toEqual({ type: 'error', text: 'Fallback error' });
+	});
+
+	it('ignores a malformed message payload', () => {
+		const result: ActionResult = {
+			type: 'failure',
+			status: 500,
+			data: { form: { message: 'just a string' } }
+		};
+
+		expect(actionMessage(result, fallbacks)).toEqual({ type: 'error', text: 'Fallback error' });
+	});
+
+	it('reads the message off an error result', () => {
+		const result: ActionResult = { type: 'error', status: 500, error: new Error('Boom') };
+
+		expect(actionMessage(result, fallbacks)).toEqual({ type: 'error', text: 'Boom' });
+	});
+
+	it('uses the error fallback when an error result carries a non-Error', () => {
+		const result: ActionResult = { type: 'error', status: 500, error: 'plain string' };
+
+		expect(actionMessage(result, fallbacks)).toEqual({ type: 'error', text: 'Fallback error' });
+	});
+
+	it('treats a redirect as a success', () => {
+		const result: ActionResult = { type: 'redirect', status: 302, location: '/dashboard' };
+
+		expect(actionMessage(result, fallbacks)).toEqual({ type: 'success', text: 'Fallback success' });
+	});
+
+	it('uses the success fallback when a success carries no message', () => {
+		const result: ActionResult = { type: 'success', status: 200 };
+
+		expect(actionMessage(result, fallbacks)).toEqual({ type: 'success', text: 'Fallback success' });
+	});
+});

--- a/src/lib/utils/actionMessage.ts
+++ b/src/lib/utils/actionMessage.ts
@@ -1,0 +1,55 @@
+import type { ActionResult } from '@sveltejs/kit';
+
+function isMessage(value: unknown): value is App.Superforms.Message {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	const candidate = value as Record<string, unknown>;
+	return (
+		(candidate.type === 'error' || candidate.type === 'success') &&
+		typeof candidate.text === 'string'
+	);
+}
+
+/**
+ * Read the `App.Superforms.Message` out of an ActionResult.
+ *
+ * Most forms in the app are superForm-driven and read `$message` directly. The two that are not
+ * (`ConfirmModal` and `PresetBudgetCard` submit via plain `use:enhance` from `$app/forms`) see the
+ * raw ActionResult instead, so this is the single place that knows how to unwrap one.
+ *
+ * The response shapes come from `docs/ERROR_HANDLING_POLICY.md`. The `data.error` branch covers
+ * actions that have not yet been migrated to that contract, plus the `requireAuth` 401 wall, which
+ * runs before `superValidate` and so has no form to carry a message.
+ */
+export function actionMessage(
+	result: ActionResult,
+	fallbacks: { success: string; error: string }
+): App.Superforms.Message {
+	if (result.type === 'redirect') {
+		return { type: 'success', text: fallbacks.success };
+	}
+
+	if (result.type === 'error') {
+		return {
+			type: 'error',
+			text: result.error instanceof Error ? result.error.message : fallbacks.error
+		};
+	}
+
+	const data = result.data as { form?: { message?: unknown }; error?: unknown } | undefined;
+
+	if (isMessage(data?.form?.message)) {
+		return data.form.message;
+	}
+
+	if (result.type === 'failure') {
+		return {
+			type: 'error',
+			text: typeof data?.error === 'string' ? data.error : fallbacks.error
+		};
+	}
+
+	return { type: 'success', text: fallbacks.success };
+}

--- a/src/routes/(app)/admin/users/+page.server.ts
+++ b/src/routes/(app)/admin/users/+page.server.ts
@@ -1,9 +1,14 @@
-import { banUserSchema, setPasswordSchema, setUserRoleSchema } from '$lib/formSchemas';
+import {
+	banUserSchema,
+	setPasswordSchema,
+	setUserRoleSchema,
+	userIdSchema
+} from '$lib/formSchemas';
 import { adminAuthFailure } from '$lib/server/actions/admin-guard';
+import { invalidAuthForm } from '$lib/server/actions/auth-form-handler';
 import { auth } from '$lib/server/auth';
 import { logger } from '$lib/server/logger';
 import type { UserWithSessions } from '$lib/types';
-import { fail } from '@sveltejs/kit';
 import { message, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 
@@ -78,14 +83,16 @@ export const load: PageServerLoad = async ({ request }) => {
 
 export const actions: Actions = {
 	setRole: async ({ request, locals }) => {
-		const authFailure = adminAuthFailure(locals);
+		// superValidate runs before the guard so the guard has a form to attach its message to.
+		const form = await superValidate(request, zod4(setUserRoleSchema));
+
+		const authFailure = adminAuthFailure(locals, form);
 		if (authFailure) {
 			return authFailure;
 		}
 
-		const form = await superValidate(request, zod4(setUserRoleSchema));
 		if (!form.valid) {
-			return fail(400, { form });
+			return invalidAuthForm(form);
 		}
 
 		try {
@@ -98,7 +105,7 @@ export const actions: Actions = {
 			});
 
 			logger.info(`Set role updated successfully`, { userId: form.data.userId });
-			return { success: true, form };
+			return message(form, { type: 'success', text: 'User role updated successfully' });
 		} catch (error) {
 			logger.error('Failed to set role:', error);
 			return message(
@@ -113,14 +120,15 @@ export const actions: Actions = {
 	},
 
 	setPassword: async ({ request, locals }) => {
-		const authFailure = adminAuthFailure(locals);
+		const form = await superValidate(request, zod4(setPasswordSchema));
+
+		const authFailure = adminAuthFailure(locals, form);
 		if (authFailure) {
 			return authFailure;
 		}
 
-		const form = await superValidate(request, zod4(setPasswordSchema));
 		if (!form.valid) {
-			return fail(400, { form });
+			return invalidAuthForm(form);
 		}
 
 		try {
@@ -133,7 +141,7 @@ export const actions: Actions = {
 			});
 
 			logger.info(`Set password successfully`, { userId: form.data.userId });
-			return { success: true, form };
+			return message(form, { type: 'success', text: 'Password updated successfully' });
 		} catch (error) {
 			logger.error('Failed to set password:', error);
 			return message(
@@ -148,14 +156,15 @@ export const actions: Actions = {
 	},
 
 	banUser: async ({ request, locals }) => {
-		const authFailure = adminAuthFailure(locals);
+		const form = await superValidate(request, zod4(banUserSchema));
+
+		const authFailure = adminAuthFailure(locals, form);
 		if (authFailure) {
 			return authFailure;
 		}
 
-		const form = await superValidate(request, zod4(banUserSchema));
 		if (!form.valid) {
-			return fail(400, { form });
+			return invalidAuthForm(form);
 		}
 
 		try {
@@ -168,7 +177,7 @@ export const actions: Actions = {
 			});
 
 			logger.info(`User banned successfully`, { userId: form.data.userId });
-			return { success: true, form };
+			return message(form, { type: 'success', text: 'User banned successfully' });
 		} catch (error) {
 			logger.error('Failed to ban user:', error);
 			return message(
@@ -183,93 +192,87 @@ export const actions: Actions = {
 	},
 
 	unbanUser: async ({ request, locals }) => {
-		const authFailure = adminAuthFailure(locals);
+		const form = await superValidate(request, zod4(userIdSchema));
+
+		const authFailure = adminAuthFailure(locals, form);
 		if (authFailure) {
 			return authFailure;
 		}
 
-		const data = await request.formData();
-		const rawId = data.get('id');
-		const userId = typeof rawId === 'string' ? rawId : undefined;
-
-		if (!userId) {
-			return fail(400, { error: 'User ID is required' });
+		if (!form.valid) {
+			return invalidAuthForm(form, 'User ID is required');
 		}
 
 		try {
 			await auth.api.unbanUser({
 				body: {
-					userId
+					userId: form.data.id
 				},
 				headers: request.headers
 			});
 
-			logger.info(`User unbanned successfully`, { userId });
-			return { success: true };
+			logger.info(`User unbanned successfully`, { userId: form.data.id });
+			return message(form, { type: 'success', text: 'User unbanned successfully' });
 		} catch (error) {
 			logger.error('Failed to unban user:', error);
-			return fail(500, { error: 'Failed to unban user' });
+			return message(form, { type: 'error', text: 'Failed to unban user' }, { status: 500 });
 		}
 	},
 
 	revokeSession: async ({ request, locals }) => {
-		const authFailure = adminAuthFailure(locals);
+		const form = await superValidate(request, zod4(userIdSchema));
+
+		const authFailure = adminAuthFailure(locals, form);
 		if (authFailure) {
 			return authFailure;
 		}
 
-		const data = await request.formData();
-		const rawId = data.get('id');
-		const userId = typeof rawId === 'string' ? rawId : undefined;
-
-		if (!userId) {
-			return fail(400, { error: 'User ID is required' });
+		if (!form.valid) {
+			return invalidAuthForm(form, 'User ID is required');
 		}
 
 		try {
 			// Revoke all sessions for the user
 			await auth.api.revokeUserSessions({
 				body: {
-					userId
+					userId: form.data.id
 				},
 				headers: request.headers
 			});
 
-			logger.info(`User sessions revoked successfully`, { userId });
-			return { success: true };
+			logger.info(`User sessions revoked successfully`, { userId: form.data.id });
+			return message(form, { type: 'success', text: 'Sessions revoked successfully' });
 		} catch (error) {
 			logger.error('Failed to revoke sessions:', error);
-			return fail(500, { error: 'Failed to revoke sessions' });
+			return message(form, { type: 'error', text: 'Failed to revoke sessions' }, { status: 500 });
 		}
 	},
 
 	deleteUser: async ({ request, locals }) => {
-		const authFailure = adminAuthFailure(locals);
+		const form = await superValidate(request, zod4(userIdSchema));
+
+		const authFailure = adminAuthFailure(locals, form);
 		if (authFailure) {
 			return authFailure;
 		}
 
-		const data = await request.formData();
-		const rawId = data.get('id');
-		const userId = typeof rawId === 'string' ? rawId : undefined;
-
-		if (!userId) {
-			return fail(400, { error: 'User ID is required' });
+		if (!form.valid) {
+			return invalidAuthForm(form, 'User ID is required');
 		}
 
 		try {
 			await auth.api.removeUser({
 				body: {
-					userId
+					userId: form.data.id
 				},
 				headers: request.headers
 			});
 
-			logger.info('User deleted successfully', { userId });
-			return { success: true };
+			logger.info('User deleted successfully', { userId: form.data.id });
+			return message(form, { type: 'success', text: 'User deleted successfully' });
 		} catch (error) {
 			logger.error('Failed to delete user:', error);
-			return fail(500, { error: 'Failed to delete user' });
+			return message(form, { type: 'error', text: 'Failed to delete user' }, { status: 500 });
 		}
 	}
 } satisfies Actions;

--- a/src/routes/(app)/admin/users/data-table-actions.svelte
+++ b/src/routes/(app)/admin/users/data-table-actions.svelte
@@ -47,19 +47,19 @@
 		form: setRoleForm,
 		errors: setRoleErrors,
 		enhance: setRoleEnhance,
-		message: setRoleMessage,
 		submitting: setRoleSubmitting
 	} = superForm(setUserRoleForm, {
 		// svelte-ignore state_referenced_locally
 		id: `setUserRole-${user.id}`,
 		resetForm: true,
 		onUpdate: ({ form }) => {
-			if (form.valid) {
+			// Read form.message, not $message: superforms clears the store on submit and only
+			// repopulates it after onUpdate has run, so the store is always undefined here.
+			if (form.message?.type === 'success') {
 				openSetRoleDialog = false;
-				toast.success('User role updated successfully');
-			}
-			if ($setRoleMessage?.type === 'error') {
-				toast.error(`Error: ${$setRoleMessage.text}`);
+				toast.success(form.message.text);
+			} else if (form.message?.type === 'error') {
+				toast.error(form.message.text);
 			}
 		},
 		onError: ({ result }) => {
@@ -71,19 +71,17 @@
 		form: setPasswordForm,
 		errors: setPasswordErrors,
 		enhance: setPasswordEnhance,
-		message: setPasswordMessage,
 		submitting: setPasswordSubmitting
 	} = superForm(setPasswordFormData, {
 		// svelte-ignore state_referenced_locally
 		id: `setPassword-${user.id}`,
 		resetForm: true,
 		onUpdate: ({ form }) => {
-			if (form.valid) {
+			if (form.message?.type === 'success') {
 				openSetPasswordDialog = false;
-				toast.success('Password updated successfully');
-			}
-			if ($setPasswordMessage?.type === 'error') {
-				toast.error(`Error: ${$setPasswordMessage.text}`);
+				toast.success(form.message.text);
+			} else if (form.message?.type === 'error') {
+				toast.error(form.message.text);
 			}
 		},
 		onError: ({ result }) => {
@@ -95,19 +93,17 @@
 		form: banUserForm,
 		errors: banUserErrors,
 		enhance: banUserEnhance,
-		message: banUserMessage,
 		submitting: banUserSubmitting
 	} = superForm(banUserFormData, {
 		// svelte-ignore state_referenced_locally
 		id: `banUser-${user.id}`,
 		resetForm: true,
 		onUpdate: ({ form }) => {
-			if (form.valid) {
+			if (form.message?.type === 'success') {
 				openBanDialog = false;
-				toast.success('User banned successfully');
-			}
-			if ($banUserMessage?.type === 'error') {
-				toast.error(`Error: ${$banUserMessage.text}`);
+				toast.success(form.message.text);
+			} else if (form.message?.type === 'error') {
+				toast.error(form.message.text);
 			}
 		},
 		onError: ({ result }) => {

--- a/src/routes/(app)/finances/budget/+page.server.ts
+++ b/src/routes/(app)/finances/budget/+page.server.ts
@@ -6,7 +6,6 @@ import { budget, transaction } from '$lib/server/db/schema';
 import { withAuditFieldsForCreate, withAuditFieldsForUpdate } from '$lib/server/db/utils';
 import { logger } from '$lib/server/logger';
 import { getMonthYearFromUrl, padMonth } from '$lib/utils/dates';
-import { fail } from '@sveltejs/kit';
 import { and, eq, sql } from 'drizzle-orm';
 import { message, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
@@ -94,15 +93,12 @@ export const load: PageServerLoad = async ({ url }) => {
 		.groupBy(transaction.categoryId, sql`substr(${transaction.date}, 1, 7)`)
 		.all();
 
-	const form = await superValidate(zod4(budgetSchema));
-
 	return {
 		budget: await budgetQueries.findByMonthYear(month, year),
 		historicalBudgets,
 		historicalTransactions,
 		last6Months: last12Months,
-		recurring: await recurringQueries.findAll(),
-		form
+		recurring: await recurringQueries.findAll()
 	};
 };
 
@@ -145,7 +141,7 @@ export const actions = {
 			);
 		}
 
-		return { success: true, create: true, form };
+		return message(form, { type: 'success', text: 'Budget saved successfully' });
 	}),
 
 	update: requireAuth(async ({ request }, user) => {
@@ -192,27 +188,6 @@ export const actions = {
 			);
 		}
 
-		return { success: true, update: true, form };
-	}),
-
-	delete: requireAuth(async ({ request }, user) => {
-		const data = await request.formData();
-		const rawId = data.get('id');
-		const budgetId = typeof rawId === 'string' ? rawId : undefined;
-
-		if (!budgetId) {
-			return fail(400, { error: 'Budget ID is required', type: 'error' });
-		}
-
-		try {
-			await getDb().delete(budget).where(eq(budget.id, budgetId));
-
-			logger.info('budget deleted successfully by:', user.id);
-		} catch (error) {
-			logger.error('Failed to delete budget', error);
-			return fail(500, { error: 'Failed to delete budget entry.', type: 'error' });
-		}
-
-		return { success: true, delete: true };
+		return message(form, { type: 'success', text: 'Budget saved successfully' });
 	})
 } satisfies Actions;

--- a/src/routes/(app)/finances/budget/+page.svelte
+++ b/src/routes/(app)/finances/budget/+page.svelte
@@ -15,36 +15,10 @@
 	import CheckCircleIcon from '@lucide/svelte/icons/check-circle';
 	import HelpCircleIcon from '@lucide/svelte/icons/help-circle';
 	import SlidersHorizontalIcon from '@lucide/svelte/icons/sliders-horizontal';
-	import { toast } from 'svelte-sonner';
-	import { get } from 'svelte/store';
-	import { superForm } from 'sveltekit-superforms';
 
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
-
-	// Initialize superform
-	const formInstance = $derived(
-		superForm(data.form, {
-			resetForm: false,
-			onUpdate: ({ form }) => {
-				if (form.valid) {
-					toast.success('Budget saved successfully!');
-					// Reset editing states
-					editingCustomAmount = false;
-				}
-				const currentMessage = get(messageStore);
-				if (currentMessage?.type === 'error') {
-					toast.error(`Error saving budget: ${currentMessage.text}`);
-				}
-			},
-			onError: ({ result }) => {
-				toast.error(`Failed to save budget: ${result.error.message}`);
-			}
-		})
-	);
-
-	const { message: messageStore } = $derived(formInstance);
 
 	let selectedCategoryId = $state<string | null>(null);
 	let editAmount = $state<string>('');
@@ -432,6 +406,7 @@
 						onSelect={() => selectPresetAmount('custom', 0)}
 						onEdit={startEditingCustomAmount}
 						onCancel={cancelEditing}
+						onSaved={cancelEditing}
 					/>
 				</div>
 


### PR DESCRIPTION
Closes #305.

Aligns `src/routes/(app)/admin/users/+page.server.ts` and `src/routes/(app)/finances/budget/+page.server.ts` to the action response contract in `docs/ERROR_HANDLING_POLICY.md`: a redirect, a success `message(form, ...)`, or an error `message(form, ..., { status })`. No more ad-hoc `{ success: true }` or bare `fail(...)`.

## The client half was more broken than the issue described

Reading superforms' source turned up two mechanics that change what the fix has to be:

1. `message(form, msg, { status >= 400 })` sets `form.valid = false` (`dist/superValidate.js:72-74`).
2. `clearOnSubmit` defaults to `'message'`, so the message store is blanked at submit (`client/superForm.js:1138`) and only repopulated in `rebind()` (`:933`) — which runs *after* `onUpdate` (`:1378`).

So the `if ($setRoleMessage?.type === 'error')` checks in `admin/users/data-table-actions.svelte` were reading a store that is **always `undefined`**. The user-visible consequence: **server failures on `/admin/users` produced nothing at all** — no toast, dialog stuck open, no explanation. These now read `form.message` off the `onUpdate` argument, the pattern `profile/+page.svelte` already used.

`/finances/budget` had the same silence for a different reason: the page built a `superForm` but never destructured or applied its `enhance`, while `PresetBudgetCard` submits via `$app/forms`. `onUpdate` was unreachable, so the "Budget saved successfully!" toast and the `editingCustomAmount = false` reset were dead code. The card now handles its own result and calls back to reset the editor.

## Changes

**Server**
- `admin/users/+page.server.ts` — all six actions. `superValidate` moved above the guard so `adminAuthFailure` has a form to attach a message to. The three FormData-only actions (`unbanUser`, `revokeSession`, `deleteUser`) validate against a new `userIdSchema`. Reuses the existing `invalidAuthForm` rather than duplicating the validation string.
- `finances/budget/+page.server.ts` — `create`/`update` return a success message. Drops the `?/delete` action, which had no caller anywhere, and the `form` that route's `load` no longer needs.
- `admin-guard.ts` — `adminAuthFailure` takes an optional `form` and returns `message(...)` when given one. Additive, so the two unmigrated admin callers are untouched.

**Client**
- `admin/users/data-table-actions.svelte` — three `onUpdate` handlers read `form.message`; the now-unused message store destructures are gone.
- `PresetBudgetCard.svelte` — new `onSaved` prop and a submit handler that toasts the server's text.
- `finances/budget/+page.svelte` — removes the unreachable `superForm` block and its dead imports.
- `src/lib/utils/actionMessage.ts` (new, 9 unit tests) — the single place that unwraps an `ActionResult` by hand, for the two components that submit without a `superForm` instance. Its legacy `data.error` branch is what lets the nine unmigrated `ConfirmModal` call sites behave exactly as before.

**Docs** — `ERROR_HANDLING_POLICY.md` gains a "Reading the response on the client" section documenting the `form.message`-not-`$message` rule, an updated migration status, and the `requireAuth` 401 exception (it runs before `superValidate`, so it has no form to carry a message).

## Scope

Deliberately limited to the two routes named in #305. `crud-helpers.ts` and four other route files still return `{ success: true }`, and 11 more modals share the silent-failure bug — tracked in #306, along with a proposed `scripts/check-action-shapes.mjs` lint gate to stop this drifting again.

## Intentional behaviour changes

- The three admin confirm dialogs now show the server's wording, e.g. "User deleted successfully" instead of "Delete User successful!".
- Budget preset clicks now raise a success toast (previously silent).
- Server failures on both routes now surface an error toast where they previously showed nothing.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run test` — 323/323 pass across 35 files
- `npm run lint` — exit 0
- `npm run build` — succeeds
- Pre-commit hook (lint-staged: fmt, lint, `svelte-check --threshold error`) — passed

**Not yet done, needs a human:** the manual UI passes. Worth exercising, since they're what actually prove the silent-failure fix — set a role on `/admin/users` with the DB stopped (should now toast instead of doing nothing), edit the custom amount on `/finances/budget` (should toast *and* close the editor), and delete a `/savings/goals` goal that has contributions to confirm the legacy `actionMessage` fallback still surfaces its message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
