### PR TITLE
Align action response contract in crud-helpers and remaining routes (#306)

### DIFF
--- a/docs/ERROR_HANDLING_POLICY.md
+++ b/docs/ERROR_HANDLING_POLICY.md
@@ -141,21 +141,19 @@ is the only place that unwraps a result by hand.
 
 ### Migration status
 
-All `/auth` actions follow this contract, as do
-`src/routes/(app)/admin/users/+page.server.ts` and `src/routes/(app)/finances/budget/+page.server.ts`.
+Every action in the app follows this contract. `requireAuth`'s 401 is the sole exception (see below),
+and `actionMessage()` keeps its `data.error` fallback for that one case alone.
 
-Still to migrate:
+Success messages for CRUD actions come from `getCrudMessage()` in
+`src/lib/server/actions/messages.ts`, so the server owns the wording and pages render
+`form.message.text` verbatim rather than duplicating it.
 
-- `src/lib/server/actions/crud-helpers.ts` (`createCrudActions`) — consistent within itself, but
-  returns `{ success: true, create/update/delete: true }` and bare `fail(...)`. Fans out to 8 routes.
-- `src/routes/(app)/admin/archived-goals/+page.server.ts`
-- `src/routes/(app)/admin/deleted-customers/+page.server.ts`
-- `src/routes/(app)/window-cleaning/+page.server.ts` (`deleteCustomer`)
-- `src/lib/server/actions/window-cleaning-jobs.ts` (`deleteJob`)
-
-Adopt this contract when touching them. `actionMessage()` keeps a fallback for the legacy
-`fail(status, { error })` shape so these routes still surface a message in the meantime; that fallback
-can go once they are migrated.
+`createDeleteAction` in `src/lib/server/actions/crud-helpers.ts` validates against `idSchema`
+(`src/lib/formSchemas/common.ts`) rather than taking a per-caller schema. Every delete in the app
+takes an id and nothing else, so one code path covers them all — and a validated form is what lets a
+delete answer with a renderable message instead of a bare `fail(...)`. `deleteCustomer` in
+`src/routes/(app)/window-cleaning/+page.server.ts` follows the same shape by hand, because it
+soft-deletes and so cannot use `deleteAction`.
 
 ## Exceptions
 

--- a/src/lib/components/CategoryModal.svelte
+++ b/src/lib/components/CategoryModal.svelte
@@ -25,16 +25,13 @@
 		superForm(categoryForm, {
 			resetForm: true,
 			onUpdate: ({ form }) => {
-				if (form.valid) {
+				// Read form.message, not $message: superforms clears the store on submit and only
+				// repopulates it after onUpdate has run, so the store is always undefined here.
+				if (form.message?.type === 'success') {
 					open = false;
-					toast.success(
-						isEditing ? 'Category updated successfully!' : 'Category created successfully!'
-					);
-				}
-				if ($message?.type === 'error') {
-					toast.error(
-						`Error ${isEditing ? 'updating' : 'creating'} category. Reason: ${$message.text}`
-					);
+					toast.success(form.message.text);
+				} else if (form.message?.type === 'error') {
+					toast.error(form.message.text);
 				}
 			},
 			onError: ({ result }) => {
@@ -46,7 +43,7 @@
 		})
 	);
 
-	const { form, errors, enhance, message, submitting } = $derived(formInstance);
+	const { form, errors, enhance, submitting } = $derived(formInstance);
 
 	$effect(() => {
 		if (open) {

--- a/src/lib/components/ContributionModal.svelte
+++ b/src/lib/components/ContributionModal.svelte
@@ -42,7 +42,9 @@
 		superForm(contributionForm, {
 			resetForm: true,
 			onUpdate: ({ form }) => {
-				if (form.valid) {
+				// Read form.message, not $message: superforms clears the store on submit and only
+				// repopulates it after onUpdate has run, so the store is always undefined here.
+				if (form.message?.type === 'success') {
 					const successPayload: ContributionSuccessPayload = {
 						goalId: form.data.goalId,
 						amount: form.data.amount
@@ -55,14 +57,9 @@
 
 					onSuccess?.(successPayload);
 					open = false;
-					toast.success(
-						isEditing ? 'Contribution updated successfully!' : 'Contribution added successfully!'
-					);
-				}
-				if ($message?.type === 'error') {
-					toast.error(
-						`Error ${isEditing ? 'updating' : 'adding'} contribution. Reason: ${$message.text}`
-					);
+					toast.success(form.message.text);
+				} else if (form.message?.type === 'error') {
+					toast.error(form.message.text);
 				}
 			},
 			onError: ({ result }) => {
@@ -73,7 +70,7 @@
 		})
 	);
 
-	const { form, errors, enhance, message, submitting } = $derived(formInstance);
+	const { form, errors, enhance, submitting } = $derived(formInstance);
 
 	$effect(() => {
 		if (open) {

--- a/src/lib/components/IncomeModal.svelte
+++ b/src/lib/components/IncomeModal.svelte
@@ -26,16 +26,13 @@
 		superForm(incomeForm, {
 			resetForm: true,
 			onUpdate: ({ form }) => {
-				if (form.valid) {
+				// Read form.message, not $message: superforms clears the store on submit and only
+				// repopulates it after onUpdate has run, so the store is always undefined here.
+				if (form.message?.type === 'success') {
 					open = false;
-					toast.success(
-						isEditing ? 'Income updated successfully!' : 'Income created successfully!'
-					);
-				}
-				if ($message?.type === 'error') {
-					toast.error(
-						`Error ${isEditing ? 'updating' : 'creating'} income. Reason: ${$message.text}`
-					);
+					toast.success(form.message.text);
+				} else if (form.message?.type === 'error') {
+					toast.error(form.message.text);
 				}
 			},
 			onError: ({ result }) => {
@@ -47,7 +44,7 @@
 		})
 	);
 
-	const { form, errors, enhance, message, submitting } = $derived(formInstance);
+	const { form, errors, enhance, submitting } = $derived(formInstance);
 
 	$effect(() => {
 		if (open) {

--- a/src/lib/components/RecurringModal.svelte
+++ b/src/lib/components/RecurringModal.svelte
@@ -25,18 +25,13 @@
 		superForm(recurringForm, {
 			resetForm: true,
 			onUpdate: ({ form }) => {
-				if (form.valid) {
+				// Read form.message, not $message: superforms clears the store on submit and only
+				// repopulates it after onUpdate has run, so the store is always undefined here.
+				if (form.message?.type === 'success') {
 					open = false;
-					toast.success(
-						isEditing
-							? 'Recurring expense updated successfully!'
-							: 'Recurring expense created successfully!'
-					);
-				}
-				if ($message?.type === 'error') {
-					toast.error(
-						`Error ${isEditing ? 'updating' : 'creating'} recurring expense. Reason: ${$message.text}`
-					);
+					toast.success(form.message.text);
+				} else if (form.message?.type === 'error') {
+					toast.error(form.message.text);
 				}
 			},
 			onError: ({ result }) => {
@@ -48,7 +43,7 @@
 		})
 	);
 
-	const { form, errors, enhance, message, submitting } = $derived(formInstance);
+	const { form, errors, enhance, submitting } = $derived(formInstance);
 
 	// Reset form when modal opens
 	$effect(() => {

--- a/src/lib/components/SavingsGoalModal.svelte
+++ b/src/lib/components/SavingsGoalModal.svelte
@@ -22,16 +22,13 @@
 		superForm(savingsGoalForm, {
 			resetForm: true,
 			onUpdate: ({ form }) => {
-				if (form.valid) {
+				// Read form.message, not $message: superforms clears the store on submit and only
+				// repopulates it after onUpdate has run, so the store is always undefined here.
+				if (form.message?.type === 'success') {
 					open = false;
-					toast.success(
-						isEditing ? 'Savings goal updated successfully!' : 'Savings goal created successfully!'
-					);
-				}
-				if ($message?.type === 'error') {
-					toast.error(
-						`Error ${isEditing ? 'updating' : 'creating'} savings goal. Reason: ${$message.text}`
-					);
+					toast.success(form.message.text);
+				} else if (form.message?.type === 'error') {
+					toast.error(form.message.text);
 				}
 			},
 			onError: ({ result }) => {
@@ -42,7 +39,7 @@
 		})
 	);
 
-	const { form, errors, enhance, message, submitting } = $derived(formInstance);
+	const { form, errors, enhance, submitting } = $derived(formInstance);
 
 	// Determine available status options based on current status
 	const availableStatuses = $derived(() => {

--- a/src/lib/components/SavingsModal.svelte
+++ b/src/lib/components/SavingsModal.svelte
@@ -20,16 +20,13 @@
 		superForm(savingsForm, {
 			resetForm: true,
 			onUpdate: ({ form }) => {
-				if (form.valid) {
+				// Read form.message, not $message: superforms clears the store on submit and only
+				// repopulates it after onUpdate has run, so the store is always undefined here.
+				if (form.message?.type === 'success') {
 					open = false;
-					toast.success(
-						isEditing ? 'Savings updated successfully!' : 'Savings created successfully!'
-					);
-				}
-				if ($message?.type === 'error') {
-					toast.error(
-						`Error ${isEditing ? 'updating' : 'creating'} savings. Reason: ${$message.text}`
-					);
+					toast.success(form.message.text);
+				} else if (form.message?.type === 'error') {
+					toast.error(form.message.text);
 				}
 			},
 			onError: ({ result }) => {
@@ -41,7 +38,7 @@
 		})
 	);
 
-	const { form, errors, enhance, message, submitting } = $derived(formInstance);
+	const { form, errors, enhance, submitting } = $derived(formInstance);
 
 	$effect(() => {
 		if (open) {

--- a/src/lib/components/TransactionModal.svelte
+++ b/src/lib/components/TransactionModal.svelte
@@ -26,16 +26,13 @@
 		superForm(transactionForm, {
 			resetForm: true,
 			onUpdate: ({ form }) => {
-				if (form.valid) {
+				// Read form.message, not $message: superforms clears the store on submit and only
+				// repopulates it after onUpdate has run, so the store is always undefined here.
+				if (form.message?.type === 'success') {
 					open = false;
-					toast.success(
-						isEditing ? 'Transaction updated successfully!' : 'Transaction created successfully!'
-					);
-				}
-				if ($message?.type === 'error') {
-					toast.error(
-						`Error ${isEditing ? 'updating' : 'creating'} transaction. Reason: ${$message.text}`
-					);
+					toast.success(form.message.text);
+				} else if (form.message?.type === 'error') {
+					toast.error(form.message.text);
 				}
 			},
 			onError: ({ result }) => {
@@ -47,7 +44,7 @@
 		})
 	);
 
-	const { form, errors, enhance, message, submitting } = $derived(formInstance);
+	const { form, errors, enhance, submitting } = $derived(formInstance);
 
 	$effect(() => {
 		if (open) {

--- a/src/lib/components/WindowCleaningCustomerModal.svelte
+++ b/src/lib/components/WindowCleaningCustomerModal.svelte
@@ -26,16 +26,13 @@
 		superForm(customerForm, {
 			resetForm: true,
 			onUpdate: ({ form }) => {
-				if (form.valid) {
+				// Read form.message, not $message: superforms clears the store on submit and only
+				// repopulates it after onUpdate has run, so the store is always undefined here.
+				if (form.message?.type === 'success') {
 					open = false;
-					toast.success(
-						isEditing ? 'Customer updated successfully!' : 'Customer added successfully!'
-					);
-				}
-				if ($message?.type === 'error') {
-					toast.error(
-						`Error ${isEditing ? 'updating' : 'adding'} customer. Reason: ${$message.text}`
-					);
+					toast.success(form.message.text);
+				} else if (form.message?.type === 'error') {
+					toast.error(form.message.text);
 				}
 			},
 			onError: ({ result }) => {
@@ -46,7 +43,7 @@
 		})
 	);
 
-	const { form, errors, enhance, message, submitting } = $derived(formInstance);
+	const { form, errors, enhance, submitting } = $derived(formInstance);
 
 	$effect(() => {
 		if (open) {

--- a/src/lib/components/WindowCleaningJobModal.svelte
+++ b/src/lib/components/WindowCleaningJobModal.svelte
@@ -29,12 +29,13 @@
 		superForm(jobForm, {
 			resetForm: true,
 			onUpdate: ({ form }) => {
-				if (form.valid) {
+				// Read form.message, not $message: superforms clears the store on submit and only
+				// repopulates it after onUpdate has run, so the store is always undefined here.
+				if (form.message?.type === 'success') {
 					open = false;
-					toast.success(isEditing ? 'Job updated successfully!' : 'Job logged successfully!');
-				}
-				if ($message?.type === 'error') {
-					toast.error(`Error ${isEditing ? 'updating' : 'logging'} job. Reason: ${$message.text}`);
+					toast.success(form.message.text);
+				} else if (form.message?.type === 'error') {
+					toast.error(form.message.text);
 				}
 			},
 			onError: ({ result }) => {
@@ -45,7 +46,7 @@
 		})
 	);
 
-	const { form, errors, enhance, message, submitting } = $derived(formInstance);
+	const { form, errors, enhance, submitting } = $derived(formInstance);
 
 	$effect(() => {
 		if (open) {

--- a/src/lib/formSchemas/common.ts
+++ b/src/lib/formSchemas/common.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+/**
+ * Id-only payload, used by actions whose entire input is the record to act on —
+ * notably the default `deleteSchema` in `src/lib/server/actions/crud-helpers.ts`.
+ */
+export const idSchema = z.object({
+	id: z.string().min(1, 'ID is required')
+});

--- a/src/lib/formSchemas/index.ts
+++ b/src/lib/formSchemas/index.ts
@@ -10,6 +10,7 @@ export {
 } from './auth';
 export { budgetSchema } from './budget';
 export { categorySchema } from './categories';
+export { idSchema } from './common';
 export { incomeSchema, recurringSchema, transactionSchema } from './finances';
 export { contributionSchema, savingsGoalSchema, savingsSchema, unArchiveSchema } from './savings';
 export {

--- a/src/lib/formSchemas/savings.ts
+++ b/src/lib/formSchemas/savings.ts
@@ -42,10 +42,6 @@ export const contributionSchema = z.object({
 		.optional()
 });
 
-export const deleteSchema = z.object({
-	id: z.string().min(1, 'ID is required')
-});
-
 export const unArchiveSchema = z.object({
 	goalId: z.string().min(1, 'Goal ID is required')
 });

--- a/src/lib/server/actions/crud-helpers.test.ts
+++ b/src/lib/server/actions/crud-helpers.test.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 
 type MockState = {
 	superValidateResult: { valid: boolean; data: Record<string, unknown> };
-	fail: ReturnType<typeof vi.fn>;
 	message: ReturnType<typeof vi.fn>;
 	superValidate: ReturnType<typeof vi.fn>;
 	insertReturning: ReturnType<typeof vi.fn>;
@@ -37,16 +36,6 @@ type MockState = {
 const mockState: MockState = vi.hoisted((): MockState => {
 	const state = {
 		superValidateResult: { valid: true, data: {} as Record<string, unknown> },
-		fail: vi.fn<
-			(
-				status: number,
-				data: Record<string, unknown>
-			) => { status: number; data: Record<string, unknown>; __failure: boolean }
-		>((status, data) => ({
-			status,
-			data,
-			__failure: true
-		})),
 		message: vi.fn<
 			(
 				form: Record<string, unknown>,
@@ -145,10 +134,6 @@ mockState.db = {
 	delete: mockState.deleteFrom
 };
 
-vi.mock('@sveltejs/kit', () => ({
-	fail: mockState.fail
-}));
-
 vi.mock('sveltekit-superforms', () => ({
 	superValidate: mockState.superValidate,
 	message: mockState.message
@@ -209,7 +194,6 @@ describe('crud-helpers', () => {
 			valid: true,
 			data: { id: 'record-1', name: 'Row 1', amount: 10 }
 		};
-		mockState.fail.mockClear();
 		mockState.message.mockClear();
 		mockState.superValidate.mockClear();
 		mockState.insertReturning.mockReset();
@@ -231,17 +215,22 @@ describe('crud-helpers', () => {
 		mockState.loggerError.mockClear();
 	});
 
-	it('createAction returns 400 when form is invalid', async () => {
+	it('createAction returns a 400 message when form is invalid', async () => {
 		mockState.superValidateResult = { valid: false, data: {} };
 		const action = createAction({ schema: baseSchema, table: mockTable, entityName: 'Thing' });
 
 		const result = await action(makeEvent() as never);
 
-		expect(mockState.fail).toHaveBeenCalledWith(400, { form: mockState.superValidateResult });
+		expect(mockState.message).toHaveBeenCalledWith(
+			mockState.superValidateResult,
+			{ type: 'error', text: 'Please correct the errors in the form.' },
+			{ status: 400 }
+		);
 		expect(result).toEqual({
 			status: 400,
-			data: { form: mockState.superValidateResult },
-			__failure: true
+			form: mockState.superValidateResult,
+			message: { type: 'error', text: 'Please correct the errors in the form.' },
+			__message: true
 		});
 	});
 
@@ -276,7 +265,16 @@ describe('crud-helpers', () => {
 		expect(inserted.createdBy).toBe('user-1');
 		expect(inserted.updatedBy).toBe('user-1');
 		expect(mockState.afterCreate).toHaveBeenCalledWith('new-id', { id: 'new-id', name: 'created' });
-		expect(result).toEqual({ success: true, create: true, form: mockState.superValidateResult });
+		expect(mockState.message).toHaveBeenCalledWith(mockState.superValidateResult, {
+			type: 'success',
+			text: 'Thing created successfully'
+		});
+		expect(result).toEqual({
+			status: 200,
+			form: mockState.superValidateResult,
+			message: { type: 'success', text: 'Thing created successfully' },
+			__message: true
+		});
 	});
 
 	it('updateAction requires id', async () => {
@@ -285,11 +283,16 @@ describe('crud-helpers', () => {
 
 		const result = await action(makeEvent() as never);
 
-		expect(mockState.fail).toHaveBeenCalledWith(400, { error: 'ID is required for update' });
+		expect(mockState.message).toHaveBeenCalledWith(
+			mockState.superValidateResult,
+			{ type: 'error', text: 'ID is required for update' },
+			{ status: 400 }
+		);
 		expect(result).toEqual({
 			status: 400,
-			data: { error: 'ID is required for update' },
-			__failure: true
+			form: mockState.superValidateResult,
+			message: { type: 'error', text: 'ID is required for update' },
+			__message: true
 		});
 	});
 
@@ -329,7 +332,16 @@ describe('crud-helpers', () => {
 			expect.objectContaining({ name: 'Row 1' }),
 			undefined
 		);
-		expect(result).toEqual({ success: true, update: true, form: mockState.superValidateResult });
+		expect(mockState.message).toHaveBeenCalledWith(mockState.superValidateResult, {
+			type: 'success',
+			text: 'Thing updated successfully'
+		});
+		expect(result).toEqual({
+			status: 200,
+			form: mockState.superValidateResult,
+			message: { type: 'success', text: 'Thing updated successfully' },
+			__message: true
+		});
 	});
 
 	it('updateAction passes beforeUpdate context to afterUpdate', async () => {
@@ -359,16 +371,49 @@ describe('crud-helpers', () => {
 	});
 
 	it('deleteAction without id fails validation', async () => {
+		mockState.superValidateResult = { valid: false, data: {} };
 		const action = deleteAction({ table: mockTable, entityName: 'Thing' });
 
 		const result = await action(makeEvent() as never);
 
-		expect(mockState.fail).toHaveBeenCalledWith(400, { hasId: false });
-		expect(result).toEqual({ status: 400, data: { hasId: false }, __failure: true });
+		expect(mockState.message).toHaveBeenCalledWith(
+			mockState.superValidateResult,
+			{ type: 'error', text: 'Please correct the errors in the form.' },
+			{ status: 400 }
+		);
+		expect(result).toEqual({
+			status: 400,
+			form: mockState.superValidateResult,
+			message: { type: 'error', text: 'Please correct the errors in the form.' },
+			__message: true
+		});
+		expect(mockState.deleteFrom).not.toHaveBeenCalled();
+	});
+
+	it('deleteAction deletes the record and returns a success message', async () => {
+		mockState.superValidateResult = { valid: true, data: { id: 'row-1' } };
+		const afterDelete = mockState.afterDelete as unknown as NonNullable<
+			Parameters<typeof deleteAction>[0]['afterDelete']
+		>;
+
+		const action = deleteAction({ table: mockTable, entityName: 'Thing', afterDelete });
+
+		const result = await action(makeEvent([['id', 'row-1']]) as never);
+
+		expect(mockState.deleteFrom).toHaveBeenCalledWith(mockTable);
+		expect(mockState.deleteWhere).toHaveBeenCalledWith({ field: 'id-column', value: 'row-1' });
+		expect(mockState.afterDelete).toHaveBeenCalledWith('row-1');
+		expect(result).toEqual({
+			status: 200,
+			form: mockState.superValidateResult,
+			message: { type: 'success', text: 'Thing deleted successfully' },
+			__message: true
+		});
 	});
 
 	it('deleteAction returns hook error from beforeDelete', async () => {
-		mockState.beforeDelete.mockResolvedValue({ error: 'Cannot delete' });
+		mockState.superValidateResult = { valid: true, data: { id: 'row-2' } };
+		mockState.beforeDelete.mockResolvedValue({ error: 'Blocked by dependency' });
 		const beforeDelete = mockState.beforeDelete as unknown as NonNullable<
 			Parameters<typeof deleteAction>[0]['beforeDelete']
 		>;
@@ -379,30 +424,9 @@ describe('crud-helpers', () => {
 			beforeDelete
 		});
 
-		const result = await action(makeEvent([['id', 'row-1']]) as never);
-
-		expect(mockState.beforeDelete).toHaveBeenCalledWith('row-1', 'user-1');
-		expect(mockState.fail).toHaveBeenCalledWith(400, { error: 'Cannot delete' });
-		expect(result).toEqual({ status: 400, data: { error: 'Cannot delete' }, __failure: true });
-		expect(mockState.deleteFrom).not.toHaveBeenCalled();
-	});
-
-	it('deleteAction with schema uses superforms message for hook errors', async () => {
-		mockState.superValidateResult = { valid: true, data: { id: 'row-2' } };
-		mockState.beforeDelete.mockResolvedValue({ error: 'Blocked by dependency' });
-		const beforeDelete = mockState.beforeDelete as unknown as NonNullable<
-			Parameters<typeof deleteAction>[0]['beforeDelete']
-		>;
-
-		const action = deleteAction({
-			table: mockTable,
-			entityName: 'Thing',
-			beforeDelete,
-			deleteSchema: z.object({ id: z.string() })
-		});
-
 		const result = await action(makeEvent([['id', 'row-2']]) as never);
 
+		expect(mockState.beforeDelete).toHaveBeenCalledWith('row-2', 'user-1');
 		expect(mockState.message).toHaveBeenCalledWith(
 			mockState.superValidateResult,
 			{ type: 'error', text: 'Blocked by dependency' },
@@ -412,6 +436,24 @@ describe('crud-helpers', () => {
 			status: 400,
 			form: mockState.superValidateResult,
 			message: { type: 'error', text: 'Blocked by dependency' },
+			__message: true
+		});
+		expect(mockState.deleteFrom).not.toHaveBeenCalled();
+	});
+
+	it('deleteAction returns a 500 message on database exception', async () => {
+		mockState.superValidateResult = { valid: true, data: { id: 'row-3' } };
+		mockState.deleteWhere.mockRejectedValueOnce(new Error('delete failed'));
+
+		const action = deleteAction({ table: mockTable, entityName: 'Thing' });
+
+		const result = await action(makeEvent([['id', 'row-3']]) as never);
+
+		expect(mockState.loggerError).toHaveBeenCalled();
+		expect(result).toEqual({
+			status: 500,
+			form: mockState.superValidateResult,
+			message: { type: 'error', text: 'Failed to delete thing. A database error occurred.' },
 			__message: true
 		});
 	});

--- a/src/lib/server/actions/crud-helpers.ts
+++ b/src/lib/server/actions/crud-helpers.ts
@@ -1,11 +1,11 @@
+import { idSchema } from '$lib/formSchemas';
 import { getDb } from '$lib/server/db';
 import { withAuditFieldsForCreate, withAuditFieldsForUpdate } from '$lib/server/db/utils';
 import { logger } from '$lib/server/logger';
 import type { RequestEvent } from '@sveltejs/kit';
-import { fail } from '@sveltejs/kit';
 import { eq, getTableColumns } from 'drizzle-orm';
 import type { SQLiteTableWithColumns } from 'drizzle-orm/sqlite-core';
-import { message, superValidate } from 'sveltekit-superforms';
+import { message, type SuperValidated, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 import type { z, ZodType } from 'zod';
 
@@ -83,6 +83,18 @@ interface CrudConfig<
 }
 
 /**
+ * The single validation-failure response, per `docs/ERROR_HANDLING_POLICY.md`. Superforms turns a
+ * `message(...)` with a 4xx status into `fail(status, { form })`, so the page gets field errors
+ * *and* a banner from one call — no bare `fail(...)` and nothing for a page to branch on.
+ */
+function invalidForm<TForm extends Record<string, unknown>>(
+	form: SuperValidated<TForm>,
+	text = 'Please correct the errors in the form.'
+) {
+	return message(form, { type: 'error', text }, { status: 400 });
+}
+
+/**
  * Create a generic create action handler
  */
 function createCreateAction<
@@ -94,7 +106,7 @@ function createCreateAction<
 		const form = await superValidate(event.request, zod4(config.schema));
 
 		if (!form.valid) {
-			return fail(400, { form });
+			return invalidForm(form);
 		}
 
 		const userId = user.id;
@@ -149,7 +161,10 @@ function createCreateAction<
 			);
 		}
 
-		return { success: true, create: true, form };
+		return message(form, {
+			type: 'success',
+			text: getCrudMessage('createSuccess', config.entityName, config.messages)
+		});
 	});
 }
 
@@ -165,12 +180,12 @@ function createUpdateAction<
 		const form = await superValidate(event.request, zod4(config.schema));
 
 		if (!form.valid) {
-			return fail(400, { form });
+			return invalidForm(form);
 		}
 
 		const recordId = (form.data as Record<string, unknown> & { id?: string }).id;
 		if (!recordId) {
-			return fail(400, { error: 'ID is required for update' });
+			return invalidForm(form, 'ID is required for update');
 		}
 
 		const userId = user.id;
@@ -225,76 +240,32 @@ function createUpdateAction<
 			);
 		}
 
-		return { success: true, update: true, form };
+		return message(form, {
+			type: 'success',
+			text: getCrudMessage('updateSuccess', config.entityName, config.messages)
+		});
 	});
 }
 
 /**
- * Create a generic delete action handler
+ * Create a generic delete action handler.
+ *
+ * Every delete in the app takes an id and nothing else, so this validates against `idSchema`
+ * rather than a per-caller schema. That keeps it on one code path, and so on the response
+ * contract in `docs/ERROR_HANDLING_POLICY.md` — the raw-FormData variant it replaced could only
+ * answer with a bare `fail(...)`, which no page could render.
  */
 function createDeleteAction<TTable extends AnySQLiteTable>(
-	config: Omit<CrudConfig<AnyZodSchema, TTable, unknown>, 'schema'> & {
-		deleteSchema?: AnyZodSchema;
-	}
+	config: Omit<CrudConfig<AnyZodSchema, TTable, unknown>, 'schema'>
 ) {
-	// If a deleteSchema is provided, use superforms validation
-	if (config.deleteSchema) {
-		const deleteSchema = config.deleteSchema; // Type guard
-		return requireAuth(async (event: RequestEvent, user) => {
-			const form = await superValidate(event.request, zod4(deleteSchema));
-
-			if (!form.valid) {
-				return fail(400, { form });
-			}
-
-			const recordId = (form.data as Record<string, unknown> & { id: string }).id;
-			const userId = user.id;
-
-			try {
-				// Run beforeDelete hook if provided
-				if (config.beforeDelete) {
-					const result = await config.beforeDelete(recordId, userId);
-					if (result && 'error' in result) {
-						return message(form, { type: 'error', text: result.error }, { status: 400 });
-					}
-				}
-
-				// Delete from database
-				const columns = getTableColumns(config.table);
-				await getDb().delete(config.table).where(eq(columns.id, recordId));
-
-				logger.info(`${config.entityName} deleted successfully by:`, userId);
-
-				// Run afterDelete hook if provided
-				if (config.afterDelete) {
-					await config.afterDelete(recordId);
-				}
-			} catch (error) {
-				logger.error(`Failed to delete ${config.entityName.toLowerCase()}`, error);
-				return message(
-					form,
-					{
-						type: 'error',
-						text: getCrudMessage('deleteError', config.entityName, config.messages)
-					},
-					{ status: 500 }
-				);
-			}
-
-			return { success: true, delete: true, form };
-		});
-	}
-
-	// Otherwise use FormData
 	return requireAuth(async (event: RequestEvent, user) => {
-		const data = await event.request.formData();
-		const hasId = data.has('id');
+		const form = await superValidate(event.request, zod4(idSchema));
 
-		if (!hasId) {
-			return fail(400, { hasId });
+		if (!form.valid) {
+			return invalidForm(form);
 		}
 
-		const recordId = data.get('id') as string;
+		const recordId = (form.data as Record<string, unknown> & { id: string }).id;
 		const userId = user.id;
 
 		try {
@@ -302,7 +273,7 @@ function createDeleteAction<TTable extends AnySQLiteTable>(
 			if (config.beforeDelete) {
 				const result = await config.beforeDelete(recordId, userId);
 				if (result && 'error' in result) {
-					return fail(400, { error: result.error });
+					return message(form, { type: 'error', text: result.error }, { status: 400 });
 				}
 			}
 
@@ -318,12 +289,20 @@ function createDeleteAction<TTable extends AnySQLiteTable>(
 			}
 		} catch (error) {
 			logger.error(`Failed to delete ${config.entityName.toLowerCase()}`, error);
-			return fail(500, {
-				error: getCrudMessage('deleteError', config.entityName, config.messages)
-			});
+			return message(
+				form,
+				{
+					type: 'error',
+					text: getCrudMessage('deleteError', config.entityName, config.messages)
+				},
+				{ status: 500 }
+			);
 		}
 
-		return { success: true, delete: true };
+		return message(form, {
+			type: 'success',
+			text: getCrudMessage('deleteSuccess', config.entityName, config.messages)
+		});
 	});
 }
 
@@ -384,9 +363,7 @@ export function updateAction<
 }
 
 export function deleteAction<TTable extends AnySQLiteTable>(
-	config: Omit<CrudConfig<AnyZodSchema, TTable, unknown>, 'schema'> & {
-		deleteSchema?: AnyZodSchema;
-	}
+	config: Omit<CrudConfig<AnyZodSchema, TTable, unknown>, 'schema'>
 ) {
 	return createDeleteAction(config);
 }

--- a/src/lib/server/actions/window-cleaning-jobs.test.ts
+++ b/src/lib/server/actions/window-cleaning-jobs.test.ts
@@ -1,57 +1,25 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — must be defined before any module imports
 // ---------------------------------------------------------------------------
 
 type MockState = {
-	fail: ReturnType<typeof vi.fn>;
-	deleteWhere: ReturnType<typeof vi.fn>;
-	deleteFrom: ReturnType<typeof vi.fn>;
-	db: { delete: ReturnType<typeof vi.fn> };
-	loggerInfo: ReturnType<typeof vi.fn>;
-	loggerError: ReturnType<typeof vi.fn>;
-	requireAuth: ReturnType<typeof vi.fn>;
 	updateAction: ReturnType<typeof vi.fn>;
+	deleteAction: ReturnType<typeof vi.fn>;
 };
 
 const mockState: MockState = vi.hoisted((): MockState => {
-	const state = {
-		fail: vi.fn<
-			(
-				status: number,
-				data: Record<string, unknown>
-			) => { status: number; data: Record<string, unknown>; __failure: boolean }
-		>((status, data) => ({ status, data, __failure: true })),
-		deleteWhere: vi.fn<() => Promise<unknown[]>>(async () => []),
-		deleteFrom: vi.fn<() => unknown>(),
-		db: { delete: vi.fn<() => unknown>() },
-		loggerInfo: vi.fn<() => void>(),
-		loggerError: vi.fn<() => void>(),
-		requireAuth: vi.fn<
-			(
-				handler: (event: unknown, user: { id: string }) => Promise<unknown>
-			) => (event: unknown) => Promise<unknown>
-		>((handler) => async (event) => handler(event, { id: 'user-1' })),
-		updateAction: vi.fn<() => ReturnType<typeof vi.fn<() => void>>>(() => vi.fn<() => void>())
+	return {
+		updateAction: vi.fn<() => ReturnType<typeof vi.fn<() => void>>>(() => vi.fn<() => void>()),
+		deleteAction: vi.fn<() => ReturnType<typeof vi.fn<() => void>>>(() => vi.fn<() => void>())
 	} as unknown as MockState;
-
-	state.deleteFrom = vi.fn<() => unknown>(() => ({ where: state.deleteWhere }));
-	state.db = { delete: state.deleteFrom };
-
-	return state;
 });
 
-vi.mock('@sveltejs/kit', () => ({ fail: mockState.fail }));
-vi.mock('$lib/server/db', () => ({ getDb: () => mockState.db }));
-vi.mock('$lib/server/logger', () => ({
-	logger: { info: mockState.loggerInfo, error: mockState.loggerError }
+vi.mock('./crud-helpers', () => ({
+	updateAction: mockState.updateAction,
+	deleteAction: mockState.deleteAction
 }));
-vi.mock('drizzle-orm', () => ({
-	eq: (field: unknown, value: unknown) => ({ field, value })
-}));
-vi.mock('./auth-guard', () => ({ requireAuth: mockState.requireAuth }));
-vi.mock('./crud-helpers', () => ({ updateAction: mockState.updateAction }));
 
 // Mock schema and schema-dependent modules after mocks are wired
 vi.mock('$lib/formSchemas', () => ({ windowCleaningJobSchema: { _tag: 'mock-schema' } }));
@@ -62,22 +30,7 @@ vi.mock('$lib/utils/dates', () => ({
 	formatDateForStorage: (d: string) => `stored:${d}`
 }));
 
-import { deleteJob } from './window-cleaning-jobs';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const makeEvent = (formEntries: Array<[string, string]> = []) => {
-	const formData = new FormData();
-	for (const [key, value] of formEntries) {
-		formData.append(key, value);
-	}
-	return {
-		request: { formData: async () => formData },
-		locals: { user: { id: 'user-1' } }
-	} as unknown as Parameters<typeof deleteJob>[0];
-};
+import './window-cleaning-jobs';
 
 // ---------------------------------------------------------------------------
 // updateJob
@@ -152,55 +105,12 @@ describe('updateJob', () => {
 // ---------------------------------------------------------------------------
 
 describe('deleteJob', () => {
-	beforeEach(() => {
-		mockState.fail.mockClear();
-		mockState.deleteWhere.mockClear();
-		mockState.deleteFrom.mockClear();
-		mockState.loggerInfo.mockClear();
-		mockState.loggerError.mockClear();
-	});
-
-	it('returns 400 when id is missing from form data', async () => {
-		const result = await deleteJob(makeEvent());
-
-		expect(mockState.fail).toHaveBeenCalledWith(400, { error: 'Job ID is required' });
-		expect(result).toEqual({
-			status: 400,
-			data: { error: 'Job ID is required' },
-			__failure: true
+	// deleteJob is now nothing but a deleteAction, so all this file owes is the wiring —
+	// validation, the delete itself, and the response contract are covered in crud-helpers.test.ts.
+	it('delegates to deleteAction with the correct table and entityName', () => {
+		expect(mockState.deleteAction).toHaveBeenCalledWith({
+			entityName: 'Job',
+			table: expect.objectContaining({ _tag: 'mock-table' })
 		});
-		expect(mockState.deleteFrom).not.toHaveBeenCalled();
-	});
-
-	it('deletes the job and returns success when id is provided', async () => {
-		const result = await deleteJob(makeEvent([['id', 'job-abc']]));
-
-		expect(mockState.deleteFrom).toHaveBeenCalledWith(
-			expect.objectContaining({ _tag: 'mock-table' })
-		);
-		expect(mockState.deleteWhere).toHaveBeenCalledWith({ field: 'id-column', value: 'job-abc' });
-		expect(mockState.loggerInfo).toHaveBeenCalledWith('Job deleted: job-abc');
-		expect(result).toEqual({ success: true, delete: true });
-	});
-
-	it('returns 500 and logs error when db throws', async () => {
-		const dbError = new Error('DB failure');
-		mockState.deleteWhere.mockRejectedValueOnce(dbError);
-
-		const result = await deleteJob(makeEvent([['id', 'job-xyz']]));
-
-		expect(mockState.fail).toHaveBeenCalledWith(500, { error: 'Failed to delete job' });
-		expect(result).toEqual({
-			status: 500,
-			data: { error: 'Failed to delete job' },
-			__failure: true
-		});
-		expect(mockState.loggerError).toHaveBeenCalledWith('Failed to delete job', dbError);
-	});
-
-	it('does not invoke the handler when user is unauthenticated', async () => {
-		// requireAuth is mocked to pass through, but we can verify requireAuth was invoked
-		// with a handler during module init — this test validates the wrapping contract.
-		expect(mockState.requireAuth).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/lib/server/actions/window-cleaning-jobs.ts
+++ b/src/lib/server/actions/window-cleaning-jobs.ts
@@ -1,13 +1,8 @@
 import { windowCleaningJobSchema } from '$lib/formSchemas';
-import { getDb } from '$lib/server/db';
 import { windowCleaningJob } from '$lib/server/db/schema';
-import { logger } from '$lib/server/logger';
 import { formatDateForStorage } from '$lib/utils/dates';
-import { fail } from '@sveltejs/kit';
-import { eq } from 'drizzle-orm';
 
-import { requireAuth } from './auth-guard';
-import { updateAction } from './crud-helpers';
+import { deleteAction, updateAction } from './crud-helpers';
 
 export const updateJob = updateAction({
 	schema: windowCleaningJobSchema,
@@ -24,20 +19,7 @@ export const updateJob = updateAction({
 	})
 });
 
-export const deleteJob = requireAuth(async (event) => {
-	const data = await event.request.formData();
-	const id = data.get('id') as string | null;
-
-	if (!id) {
-		return fail(400, { error: 'Job ID is required' });
-	}
-
-	try {
-		await getDb().delete(windowCleaningJob).where(eq(windowCleaningJob.id, id));
-		logger.info(`Job deleted: ${id}`);
-		return { success: true, delete: true };
-	} catch (error) {
-		logger.error('Failed to delete job', error);
-		return fail(500, { error: 'Failed to delete job' });
-	}
+export const deleteJob = deleteAction({
+	table: windowCleaningJob,
+	entityName: 'Job'
 });

--- a/src/lib/utils/actionMessage.ts
+++ b/src/lib/utils/actionMessage.ts
@@ -19,9 +19,9 @@ function isMessage(value: unknown): value is App.Superforms.Message {
  * (`ConfirmModal` and `PresetBudgetCard` submit via plain `use:enhance` from `$app/forms`) see the
  * raw ActionResult instead, so this is the single place that knows how to unwrap one.
  *
- * The response shapes come from `docs/ERROR_HANDLING_POLICY.md`. The `data.error` branch covers
- * actions that have not yet been migrated to that contract, plus the `requireAuth` 401 wall, which
- * runs before `superValidate` and so has no form to carry a message.
+ * The response shapes come from `docs/ERROR_HANDLING_POLICY.md`. Every action now returns a form,
+ * so the `data.error` branch is down to its last caller: the `requireAuth` 401 wall, which runs
+ * before `superValidate` and so has no form to carry a message.
  */
 export function actionMessage(
 	result: ActionResult,

--- a/src/routes/(app)/admin/archived-goals/+page.server.ts
+++ b/src/routes/(app)/admin/archived-goals/+page.server.ts
@@ -1,10 +1,10 @@
 import { unArchiveSchema } from '$lib/formSchemas';
 import { adminAuthFailure } from '$lib/server/actions/admin-guard';
+import { invalidAuthForm } from '$lib/server/actions/auth-form-handler';
 import { getDb } from '$lib/server/db';
 import { savingsGoal } from '$lib/server/db/schema';
 import { withAuditFieldsForUpdate } from '$lib/server/db/utils';
 import { logger } from '$lib/server/logger';
-import { fail } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
 import { message, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
@@ -41,17 +41,18 @@ export const load: PageServerLoad = async () => {
 
 export const actions: Actions = {
 	unarchive: async ({ request, locals }) => {
-		const authFailure = adminAuthFailure(locals);
-		if (authFailure) {
-			return authFailure;
-		}
-		if (!locals.user) {
-			return fail(401, { error: 'Unauthorized' });
+		// superValidate runs before the guard so the guard has a form to attach its message to.
+		const form = await superValidate(request, zod4(unArchiveSchema));
+
+		// The `!locals.user` arm is unreachable — adminAuthFailure already rejects anonymous
+		// callers — but it narrows the type for the audit fields below.
+		const authFailure = adminAuthFailure(locals, form);
+		if (authFailure || !locals.user) {
+			return authFailure ?? message(form, { type: 'error', text: 'Unauthorized' }, { status: 401 });
 		}
 
-		const form = await superValidate(request, zod4(unArchiveSchema));
 		if (!form.valid) {
-			return fail(400, { form });
+			return invalidAuthForm(form);
 		}
 
 		const db = getDb();
@@ -71,7 +72,7 @@ export const actions: Actions = {
 				.where(eq(savingsGoal.id, form.data.goalId));
 
 			logger.info(`Goal with ID ${form.data.goalId} updated successfully`);
-			return { success: true, form };
+			return message(form, { type: 'success', text: 'Goal unarchived successfully' });
 		} catch (error) {
 			logger.error('Failed to unarchive goal:', error);
 			return message(

--- a/src/routes/(app)/admin/archived-goals/data-table-actions.svelte
+++ b/src/routes/(app)/admin/archived-goals/data-table-actions.svelte
@@ -18,15 +18,16 @@
 		z.infer<typeof unArchiveSchema>
 	>;
 
-	const { form, enhance, message } = superForm(unArchiveForm, {
+	const { form, enhance } = superForm(unArchiveForm, {
 		resetForm: true,
 		onUpdate: async ({ form }) => {
-			if (form.valid) {
+			// Read form.message, not $message: superforms clears the store on submit and only
+			// repopulates it after onUpdate has run, so the store is always undefined here.
+			if (form.message?.type === 'success') {
 				openUnarchiveDialog = false;
-				toast.success('Goal unarchived successfully');
-			}
-			if ($message?.type === 'error') {
-				toast.error(`Error: ${$message.text}`);
+				toast.success(form.message.text);
+			} else if (form.message?.type === 'error') {
+				toast.error(form.message.text);
 			}
 		},
 		onError: ({ result }) => {

--- a/src/routes/(app)/admin/deleted-customers/+page.server.ts
+++ b/src/routes/(app)/admin/deleted-customers/+page.server.ts
@@ -1,10 +1,11 @@
 import { restoreCustomerSchema } from '$lib/formSchemas';
+import { adminAuthFailure } from '$lib/server/actions/admin-guard';
+import { invalidAuthForm } from '$lib/server/actions/auth-form-handler';
 import { requireAdmin } from '$lib/server/auth';
 import { getDb } from '$lib/server/db';
 import { windowCleaningCustomer } from '$lib/server/db/schema';
 import { withAuditFieldsForUpdate } from '$lib/server/db/utils';
 import { logger } from '$lib/server/logger';
-import { fail } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
 import { message, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
@@ -40,14 +41,18 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 export const actions: Actions = {
 	restore: async ({ request, locals }) => {
-		requireAdmin(locals);
-		if (!locals.user) {
-			return fail(401, { error: 'Unauthorized' });
+		// superValidate runs before the guard so the guard has a form to attach its message to.
+		const form = await superValidate(request, zod4(restoreCustomerSchema));
+
+		// The `!locals.user` arm is unreachable — adminAuthFailure already rejects anonymous
+		// callers — but it narrows the type for the audit fields below.
+		const authFailure = adminAuthFailure(locals, form);
+		if (authFailure || !locals.user) {
+			return authFailure ?? message(form, { type: 'error', text: 'Unauthorized' }, { status: 401 });
 		}
 
-		const form = await superValidate(request, zod4(restoreCustomerSchema));
 		if (!form.valid) {
-			return fail(400, { form });
+			return invalidAuthForm(form);
 		}
 
 		const db = getDb();
@@ -67,7 +72,7 @@ export const actions: Actions = {
 				.where(eq(windowCleaningCustomer.id, form.data.customerId));
 
 			logger.info(`Customer restored: ${form.data.customerId}`);
-			return { success: true, form };
+			return message(form, { type: 'success', text: 'Customer restored successfully' });
 		} catch (error) {
 			logger.error('Failed to restore customer', error);
 			return message(form, { type: 'error', text: 'Failed to restore customer' }, { status: 500 });

--- a/src/routes/(app)/admin/deleted-customers/data-table-actions.svelte
+++ b/src/routes/(app)/admin/deleted-customers/data-table-actions.svelte
@@ -19,15 +19,16 @@
 		z.infer<typeof restoreCustomerSchema>
 	>;
 
-	const { form, enhance, message, submitting } = superForm(restoreForm, {
+	const { form, enhance, submitting } = superForm(restoreForm, {
 		resetForm: true,
 		onUpdate: ({ form }) => {
-			if (form.valid) {
+			// Read form.message, not $message: superforms clears the store on submit and only
+			// repopulates it after onUpdate has run, so the store is always undefined here.
+			if (form.message?.type === 'success') {
 				openRestoreDialog = false;
-				toast.success('Customer restored successfully');
-			}
-			if ($message?.type === 'error') {
-				toast.error(`Error: ${$message.text}`);
+				toast.success(form.message.text);
+			} else if (form.message?.type === 'error') {
+				toast.error(form.message.text);
 			}
 		},
 		onError: ({ result }) => {

--- a/src/routes/(app)/savings/goals/+page.server.ts
+++ b/src/routes/(app)/savings/goals/+page.server.ts
@@ -1,4 +1,4 @@
-import { contributionSchema, deleteSchema, savingsGoalSchema } from '$lib/formSchemas/savings';
+import { contributionSchema, savingsGoalSchema } from '$lib/formSchemas/savings';
 import { createAction, deleteAction, updateAction } from '$lib/server/actions/crud-helpers';
 import { getDb } from '$lib/server/db';
 import { savingsGoalQueries } from '$lib/server/db/queries';
@@ -101,7 +101,6 @@ export const actions = {
 	deleteGoal: deleteAction({
 		table: savingsGoal,
 		entityName: 'Savings goal',
-		deleteSchema: deleteSchema,
 		beforeDelete: async (id) => {
 			// Check if contributions exist for this goal
 			const existingContributions = await getDb()
@@ -144,7 +143,6 @@ export const actions = {
 
 	deleteContribution: deleteAction({
 		table: contribution,
-		entityName: 'Contribution',
-		deleteSchema: deleteSchema
+		entityName: 'Contribution'
 	})
 } satisfies Actions;

--- a/src/routes/(app)/setup/recurring/+page.server.ts
+++ b/src/routes/(app)/setup/recurring/+page.server.ts
@@ -60,6 +60,7 @@ export const actions = {
 				.set(withAuditFieldsForUpdate({ paid: form.data.paid }, user))
 				.where(eq(recurring.id, form.data.id));
 			logger.info(`Toggled paid status for recurring expense ${form.data.id} to ${form.data.paid}`);
+			return message(form, { type: 'success', text: 'Paid status updated' });
 		} catch (error) {
 			logger.error('Failed to toggle recurring paid status', error);
 			return message(

--- a/src/routes/(app)/setup/recurring/data-table-actions.svelte
+++ b/src/routes/(app)/setup/recurring/data-table-actions.svelte
@@ -7,6 +7,7 @@
 	import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 	import type { recurringSchema } from '$lib/formSchemas';
+	import { actionMessage } from '$lib/utils/actionMessage';
 	import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
 	import { getContext } from 'svelte';
 	import { toast } from 'svelte-sonner';
@@ -45,11 +46,14 @@
 					togglingPaid = true;
 					return async ({ result, update }) => {
 						if (result.type === 'success') {
+							// Silent on success — a toast on every checkbox tick would be noise.
 							await invalidateAll();
-						} else if (result.type === 'failure' && result.data?.error) {
-							toast.error((result.data.error as string) || 'Failed to toggle paid status');
 						} else {
-							toast.error('Failed to toggle paid status');
+							const { text } = actionMessage(result, {
+								success: 'Paid status updated',
+								error: 'Failed to toggle paid status'
+							});
+							toast.error(text);
 						}
 
 						await update();

--- a/src/routes/(app)/window-cleaning/+page.server.ts
+++ b/src/routes/(app)/window-cleaning/+page.server.ts
@@ -1,4 +1,4 @@
-import { windowCleaningCustomerSchema, windowCleaningJobSchema } from '$lib/formSchemas';
+import { idSchema, windowCleaningCustomerSchema, windowCleaningJobSchema } from '$lib/formSchemas';
 import { requireAuth } from '$lib/server/actions/auth-guard';
 import { createAction, updateAction } from '$lib/server/actions/crud-helpers';
 import { deleteJob, updateJob } from '$lib/server/actions/window-cleaning-jobs';
@@ -9,9 +9,8 @@ import { withAuditFieldsForUpdate } from '$lib/server/db/utils';
 import { logger } from '$lib/server/logger';
 import type { WindowCleaningJob } from '$lib/types';
 import { formatDateForStorage, getCurrentUTCTimestamp } from '$lib/utils/dates';
-import { fail } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
-import { superValidate } from 'sveltekit-superforms';
+import { message, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 
 import type { Actions, PageServerLoad } from './$types';
@@ -109,14 +108,15 @@ export const actions = {
 		})
 	}),
 
-	// Soft-delete: set deletedAt/deletedBy instead of hard delete
+	// Soft-delete: set deletedAt/deletedBy instead of hard delete, so this cannot use deleteAction
 	deleteCustomer: requireAuth(async (event, user) => {
-		const data = await event.request.formData();
-		const id = data.get('id') as string | null;
+		const form = await superValidate(event.request, zod4(idSchema));
 
-		if (!id) {
-			return fail(400, { error: 'Customer ID is required' });
+		if (!form.valid) {
+			return message(form, { type: 'error', text: 'Customer ID is required' }, { status: 400 });
 		}
+
+		const id = form.data.id;
 
 		try {
 			await getDb()
@@ -133,10 +133,14 @@ export const actions = {
 				.where(eq(windowCleaningCustomer.id, id));
 
 			logger.info(`Customer soft-deleted: ${id} by ${user.id}`);
-			return { success: true, delete: true };
+			return message(form, { type: 'success', text: 'Customer deleted successfully' });
 		} catch (error) {
 			logger.error('Failed to delete customer', error);
-			return fail(500, { error: 'Failed to delete customer' });
+			return message(
+				form,
+				{ type: 'error', text: 'Failed to delete customer. A database error occurred.' },
+				{ status: 500 }
+			);
 		}
 	}),
 


### PR DESCRIPTION
Closes #306.

Every action in the app now returns one of the three shapes in `docs/ERROR_HANDLING_POLICY.md`: a redirect, a success message, or an error message with a 4xx/5xx status. No more ad-hoc `{ success: true }` and no more bare `fail(...)`.

## Server

`crud-helpers.ts` fans out to 8 routes, so its 4 return sites and 7 bare `fail(...)`s were most of the problem. Successes now carry the text `getCrudMessage()` already had templates for, so the server owns the wording.

The delete helper had two code paths — a schema one and a raw-FormData one — and only the schema path could produce a response a page could render. Since every delete in the app takes an id and nothing else, both collapse into one path validating against a new id-only `idSchema` (`src/lib/formSchemas/common.ts`), following the `userIdSchema` precedent from #305. `savings/goals` was the only caller passing its own `deleteSchema` and it was identical to the default, so the option is gone. `deleteJob` becomes a plain `deleteAction`.

Also migrated: `admin/archived-goals`, `admin/deleted-customers` (both now `superValidate` above the guard and pass their form to `adminAuthFailure`), and `window-cleaning`'s `deleteCustomer`, which soft-deletes and so does the same thing by hand.

## Client

A `$message` read inside superforms' `onUpdate` is always `undefined` — `clearOnSubmit` defaults to `'message'`, so the store is blanked at submit and only repopulated in `rebind()`, which runs after `onUpdate`. That made `if ($message?.type === 'error')` dead code in 11 more components, and the user-visible consequence was that **server failures were silent**: no toast, dialog stays open, no explanation.

They now read `form.message` off the `onUpdate` argument and render its text verbatim. `ContributionModal`'s `onSuccess?.()` stays in the success branch — it drives the confetti in `savings/goals/+page.svelte`.

Success toast wording changes slightly as a result, e.g. "Job logged successfully!" → "Job created successfully", and error toasts drop the "Error updating X. Reason: …" wrapper now that the server text is already a full sentence.

## Two judgement calls worth flagging

- **Kept `actionMessage()`'s `data.error` branch.** The issue suggested dropping it once every action returns a form, but `requireAuth`'s 401 still uses that shape, so dropping it would downgrade an expired-session failure to a generic fallback string. Comment updated to say it now covers that one case.
- **Fixed one thing the issue didn't list:** `setup/recurring`'s `togglePaid` hand-unwrapped `result.data?.error`, a shape its own action had already stopped returning, so every failure fell through to a generic toast. It uses `actionMessage()` now — the last hand-unwrap outside that helper.

Skipped the proposed `scripts/check-action-shapes.mjs` static check, per instruction.

## Verification

`npm run check`, `npm run lint` (incl. `lint:static`), and `npm run test` all pass — 321 tests, 35 files. `crud-helpers.test.ts` and `window-cleaning-jobs.test.ts` updated for the new shapes; the delete tests gained success and db-exception cases, and `window-cleaning-jobs.test.ts` drops the delete behaviour tests in favour of a wiring assertion, since that logic now lives in `crud-helpers` and is covered there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)