### PR TITLE
Fix month switcher rolling over before midnight Pacific

### DIFF
--- a/src/lib/utils/dates.test.ts
+++ b/src/lib/utils/dates.test.ts
@@ -254,6 +254,13 @@ describe('Date Utilities - Local Timezone Storage', () => {
 			const result = getMonthYearFromUrl(url);
 			expect(result).toEqual({ month: 7, year: 2025 });
 		});
+
+		it('should stay in the previous month across the UTC day boundary (Pacific 9pm July 31 = UTC Aug 1)', () => {
+			vi.setSystemTime(new Date('2026-08-01T04:00:00Z')); // 9:00pm PDT on July 31
+			const url = new URL('http://localhost/');
+			const result = getMonthYearFromUrl(url);
+			expect(result).toEqual({ month: 7, year: 2026 });
+		});
 	});
 
 	describe('getMonthRangeFromUrl', () => {
@@ -362,6 +369,15 @@ describe('Date Utilities - Local Timezone Storage', () => {
 				{ month: 1, year: 2026, startDate: '2026-01-01', endDate: '2026-01-31' }
 			]);
 		});
+
+		it('does not include the next month across the UTC day boundary (Pacific 9pm July 31 = UTC Aug 1)', () => {
+			vi.setSystemTime(new Date('2026-08-01T04:00:00Z')); // 9:00pm PDT on July 31
+			const result = getPreviousMonthsRange(2);
+			expect(result).toEqual([
+				{ month: 6, year: 2026, startDate: '2026-06-01', endDate: '2026-06-30' },
+				{ month: 7, year: 2026, startDate: '2026-07-01', endDate: '2026-07-31' }
+			]);
+		});
 	});
 
 	describe('getCalendarYearMonthsRange', () => {
@@ -397,6 +413,18 @@ describe('Date Utilities - Local Timezone Storage', () => {
 				year: 2025,
 				startDate: '2025-12-01',
 				endDate: '2025-12-31'
+			});
+		});
+
+		it('excludes August across the UTC day boundary (Pacific 9pm July 31 = UTC Aug 1)', () => {
+			vi.setSystemTime(new Date('2026-08-01T04:00:00Z')); // 9:00pm PDT on July 31
+			const result = getCalendarYearMonthsRange(2026);
+			expect(result).toHaveLength(7);
+			expect(result[6]).toEqual({
+				month: 7,
+				year: 2026,
+				startDate: '2026-07-01',
+				endDate: '2026-07-31'
 			});
 		});
 	});

--- a/src/lib/utils/dates.ts
+++ b/src/lib/utils/dates.ts
@@ -12,6 +12,8 @@ type PeriodProgressKind = 'month' | 'year';
 type PeriodProgressStatus = 'past' | 'current' | 'future';
 type PeriodProgressUnit = 'day' | 'month';
 
+const PACIFIC_TIMEZONE = 'America/Los_Angeles';
+
 export interface PeriodProgress {
 	kind: PeriodProgressKind;
 	elapsedUnits: number;
@@ -165,21 +167,60 @@ export function padMonth(month: number | string): string {
 }
 
 /**
+ * Get year/month/day parts of a date as observed in the Pacific timezone
+ * (America/Los_Angeles, which auto-adjusts for PST/PDT), regardless of the
+ * server or browser's own local timezone.
+ */
+function getPacificDateParts(date: Date = new Date()): {
+	year: number;
+	month: number;
+	day: number;
+} {
+	const formatter = new Intl.DateTimeFormat('en-US', {
+		timeZone: PACIFIC_TIMEZONE,
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit'
+	});
+	const parts = formatter.formatToParts(date);
+	const partMap = new Map(parts.map((part) => [part.type, part.value]));
+
+	return {
+		year: Number(partMap.get('year')),
+		month: Number(partMap.get('month')),
+		day: Number(partMap.get('day'))
+	};
+}
+
+/**
+ * Get the current month/year as observed in the Pacific timezone, so the
+ * month rolls over at midnight Pacific rather than midnight UTC or the
+ * server/browser's own local timezone.
+ */
+export function getCurrentPacificMonthYear(date: Date = new Date()): {
+	month: number;
+	year: number;
+} {
+	const { month, year } = getPacificDateParts(date);
+	return { month, year };
+}
+
+/**
  * Extract month and year from URL search params with fallback to current date
  * @param url - URL object containing searchParams
  * @returns Object with month (1-12) and year
  *
  * Example: URL with ?month=3&year=2025 → { month: 3, year: 2025 }
- * Example: URL with no params → { month: 1, year: 2026 } (current date)
+ * Example: URL with no params → { month: 1, year: 2026 } (current date, Pacific time)
  */
 export function getMonthYearFromUrl(url: URL): { month: number; year: number } {
-	const currentDate = new Date();
 	const monthParam = url.searchParams.get('month');
 	const yearParam = url.searchParams.get('year');
+	const current = getCurrentPacificMonthYear();
 
 	return {
-		month: monthParam ? Number.parseInt(monthParam) : currentDate.getMonth() + 1,
-		year: yearParam ? Number.parseInt(yearParam) : currentDate.getFullYear()
+		month: monthParam ? Number.parseInt(monthParam) : current.month,
+		year: yearParam ? Number.parseInt(yearParam) : current.year
 	};
 }
 
@@ -208,9 +249,8 @@ export function getMonthRangeFromUrl(url: URL) {
  *   → Returns data for Aug 2025, Sep 2025, Oct 2025, Nov 2025, Dec 2025, Jan 2026
  */
 export function getPreviousMonthsRange(count: number) {
-	const currentDate = new Date();
-	const currentMonth = currentDate.getMonth() + 1;
-	const currentYear = currentDate.getFullYear();
+	const { year: currentYear, month: currentMonth, day: currentDay } = getPacificDateParts();
+	const currentDate = new Date(currentYear, currentMonth - 1, currentDay);
 	const ranges = [];
 
 	for (let i = count - 1; i >= 0; i--) {
@@ -240,7 +280,8 @@ export function getPreviousMonthsRange(count: number) {
  *   → Returns all 12 months of 2025
  */
 export function getCalendarYearMonthsRange(year: number) {
-	const currentDate = new Date();
+	const { year: currentYear, month: currentMonth, day: currentDay } = getPacificDateParts();
+	const currentDate = new Date(currentYear, currentMonth - 1, currentDay);
 	const ranges = [];
 
 	for (let month = 1; month <= 12; month++) {

--- a/src/routes/(app)/finances/budget/+page.svelte
+++ b/src/routes/(app)/finances/budget/+page.svelte
@@ -10,7 +10,7 @@
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { getCategoriesContext } from '$lib/contexts';
 	import { months } from '$lib/utils';
-	import { padMonth } from '$lib/utils/dates';
+	import { getCurrentPacificMonthYear, padMonth } from '$lib/utils/dates';
 	import { usePendingReload } from '$lib/utils/pendingNavigation.svelte';
 	import CheckCircleIcon from '@lucide/svelte/icons/check-circle';
 	import HelpCircleIcon from '@lucide/svelte/icons/help-circle';
@@ -31,9 +31,7 @@
 	// Calculate total recurring expenses
 	let totalRecurring = $derived((data.recurring || []).reduce((sum, item) => sum + item.amount, 0));
 
-	const currentDate = new Date();
-	const defaultMonth = currentDate.getMonth() + 1;
-	const defaultYear = currentDate.getFullYear();
+	const { month: defaultMonth, year: defaultYear } = getCurrentPacificMonthYear();
 
 	let selectedMonth = $derived(Number(page.url.searchParams.get('month')) || defaultMonth);
 	let selectedYear = $derived(Number(page.url.searchParams.get('year')) || defaultYear);

--- a/src/routes/(app)/finances/income/+page.svelte
+++ b/src/routes/(app)/finances/income/+page.svelte
@@ -8,6 +8,7 @@
 	import { DataTable } from '$lib/components/ui/data-table';
 	import { incomeFormContext } from '$lib/contexts';
 	import { formatCurrency } from '$lib/utils';
+	import { getCurrentPacificMonthYear } from '$lib/utils/dates';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 
 	import type { PageProps } from './$types';
@@ -43,9 +44,7 @@
 		return yearlyTotalIncome / completedMonthsSinceJanuary;
 	});
 
-	const currentDate = new Date();
-	const defaultMonth = currentDate.getMonth() + 1;
-	const defaultYear = currentDate.getFullYear();
+	const { month: defaultMonth, year: defaultYear } = getCurrentPacificMonthYear();
 
 	let selectedMonth = $derived(Number(page.url.searchParams.get('month')) || defaultMonth);
 	let selectedYear = $derived(Number(page.url.searchParams.get('year')) || defaultYear);

--- a/src/routes/(app)/finances/transactions/+page.svelte
+++ b/src/routes/(app)/finances/transactions/+page.svelte
@@ -11,6 +11,7 @@
 	import { getCategoriesContext, transactionFormContext } from '$lib/contexts';
 	import type { transactionSchema } from '$lib/formSchemas';
 	import { formatCurrency } from '$lib/utils';
+	import { getCurrentPacificMonthYear } from '$lib/utils/dates';
 	import { calculateTransactionSummary } from '$lib/utils/transaction-summary';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 	import SearchIcon from '@lucide/svelte/icons/search';
@@ -82,9 +83,7 @@
 		});
 	}
 
-	const currentDate = new Date();
-	const defaultMonth = currentDate.getMonth() + 1;
-	const defaultYear = currentDate.getFullYear();
+	const { month: defaultMonth, year: defaultYear } = getCurrentPacificMonthYear();
 
 	let selectedMonth = $derived(Number(page.url.searchParams.get('month')) || defaultMonth);
 	let selectedYear = $derived(Number(page.url.searchParams.get('year')) || defaultYear);

--- a/src/routes/(app)/receipts/business/+page.svelte
+++ b/src/routes/(app)/receipts/business/+page.svelte
@@ -8,6 +8,7 @@
 	import { DataTable } from '$lib/components/ui/data-table';
 	import { getCategoriesContext, transactionFormContext } from '$lib/contexts';
 	import { formatCurrency } from '$lib/utils';
+	import { getCurrentPacificMonthYear } from '$lib/utils/dates';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 
 	import type { PageProps } from './$types';
@@ -46,9 +47,7 @@
 		)
 	);
 
-	const currentDate = new Date();
-	const defaultMonth = currentDate.getMonth() + 1;
-	const defaultYear = currentDate.getFullYear();
+	const { month: defaultMonth, year: defaultYear } = getCurrentPacificMonthYear();
 
 	let selectedMonth = $derived(Number(page.url.searchParams.get('month')) || defaultMonth);
 	let selectedYear = $derived(Number(page.url.searchParams.get('year')) || defaultYear);

--- a/src/routes/(app)/receipts/fuel/+page.svelte
+++ b/src/routes/(app)/receipts/fuel/+page.svelte
@@ -8,6 +8,7 @@
 	import { DataTable } from '$lib/components/ui/data-table';
 	import { getCategoriesContext, transactionFormContext } from '$lib/contexts';
 	import { formatCurrency } from '$lib/utils';
+	import { getCurrentPacificMonthYear } from '$lib/utils/dates';
 	import PlusIcon from '@lucide/svelte/icons/plus';
 
 	import type { PageProps } from './$types';
@@ -57,9 +58,7 @@
 		return yearlyTotalAmount / completedMonthsSinceJanuary;
 	});
 
-	const currentDate = new Date();
-	const defaultMonth = currentDate.getMonth() + 1;
-	const defaultYear = currentDate.getFullYear();
+	const { month: defaultMonth, year: defaultYear } = getCurrentPacificMonthYear();
 
 	let selectedMonth = $derived(Number(page.url.searchParams.get('month')) || defaultMonth);
 	let selectedYear = $derived(Number(page.url.searchParams.get('year')) || defaultYear);

--- a/src/routes/(app)/window-cleaning/jobs/+page.svelte
+++ b/src/routes/(app)/window-cleaning/jobs/+page.svelte
@@ -8,6 +8,7 @@
 	import DataTable from '$lib/components/ui/data-table/data-table.svelte';
 	import YearSwitcher from '$lib/components/YearSwitcher.svelte';
 	import type { windowCleaningJobSchema } from '$lib/formSchemas';
+	import { getCurrentPacificMonthYear } from '$lib/utils/dates';
 	import { usePendingReload } from '$lib/utils/pendingNavigation.svelte';
 	import { setContext } from 'svelte';
 	import type { SuperValidated } from 'sveltekit-superforms';
@@ -32,8 +33,7 @@
 	// svelte-ignore state_referenced_locally
 	setContext('jobForm', data.jobForm);
 
-	const currentDate = new Date();
-	const defaultYear = currentDate.getFullYear();
+	const { year: defaultYear } = getCurrentPacificMonthYear();
 
 	function parseSelectedYear(searchParam: string | null, fallbackYear: number): number {
 		if (searchParam === null) {


### PR DESCRIPTION
## Summary
- Fixes #309: the month switcher (and the data it fetches) rolled over to the next month as early as 5pm/9pm Pacific because the "current month" fallback used `new Date()`, which reflects the server's UTC clock rather than Pacific time.
- Adds `getCurrentPacificMonthYear()` to `src/lib/utils/dates.ts`, using the `Intl.DateTimeFormat` + `America/Los_Angeles` pattern already established in `weeklySummaryEmail.ts` (auto-handles PST/PDT, no new dependency).
- Uses it for the server-side `getMonthYearFromUrl` fallback (used by budget, dashboard, income, transactions, and receipts load functions), the dashboard's `getPreviousMonthsRange`/`getCalendarYearMonthsRange` "don't include future months" boundary, and the duplicated client-side default-month blocks in the budget/transactions/income/receipts/window-cleaning pages.

## Test plan
- [x] `npm run test:unit` — full suite passes (324 tests), including 3 new boundary-condition tests pinned to 9:00pm PDT July 31 / Aug 1 UTC that reproduce the exact scenario from the issue
- [x] `npm run check` — svelte-check passes with 0 errors/warnings
- [x] Pre-commit and pre-push hooks (lint, format, svelte-check, full test suite) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)