### PR TITLE
Add due dates to recurring items + Upcoming Bills dashboard widget

### DIFF
--- a/src/lib/components/RecurringModal.svelte
+++ b/src/lib/components/RecurringModal.svelte
@@ -45,6 +45,23 @@
 
 	const { form, errors, enhance, submitting } = $derived(formInstance);
 
+	const months = [
+		{ value: '1', label: 'January' },
+		{ value: '2', label: 'February' },
+		{ value: '3', label: 'March' },
+		{ value: '4', label: 'April' },
+		{ value: '5', label: 'May' },
+		{ value: '6', label: 'June' },
+		{ value: '7', label: 'July' },
+		{ value: '8', label: 'August' },
+		{ value: '9', label: 'September' },
+		{ value: '10', label: 'October' },
+		{ value: '11', label: 'November' },
+		{ value: '12', label: 'December' }
+	];
+
+	const dueMonthLabel = $derived(months.find((m) => m.value === String($form.dueMonth))?.label);
+
 	// Reset form when modal opens
 	$effect(() => {
 		if (open) {
@@ -54,12 +71,16 @@
 				$form.description = initialData.description || '';
 				$form.cadence = initialData.cadence || 'Monthly';
 				$form.amount = initialData?.amount || 0;
+				$form.dueDay = initialData.dueDay ?? null;
+				$form.dueMonth = initialData.dueMonth ?? null;
 			} else {
 				$form.id = '';
 				$form.merchant = '';
 				$form.description = '';
 				$form.cadence = 'Monthly';
 				$form.amount = 0;
+				$form.dueDay = null;
+				$form.dueMonth = null;
 			}
 		}
 	});
@@ -130,6 +151,50 @@
 				</Select.Root>
 				{#if $errors.cadence}
 					<p class="text-sm text-red-500">{$errors.cadence}</p>
+				{/if}
+			</div>
+
+			<div class="flex gap-4">
+				<div class="space-y-2 {$form.cadence === 'Yearly' ? 'w-1/2' : 'w-full'}">
+					<label for="recurring-due-day" class="text-sm font-medium">Due day</label>
+					<Input
+						id="recurring-due-day"
+						name="dueDay"
+						type="number"
+						min="1"
+						max="31"
+						bind:value={$form.dueDay}
+						placeholder="e.g. 15"
+						class={$errors.dueDay ? 'border-red-400' : ''}
+					/>
+					{#if $errors.dueDay}
+						<p class="text-sm text-red-500">{$errors.dueDay}</p>
+					{/if}
+				</div>
+
+				{#if $form.cadence === 'Yearly'}
+					<div class="w-1/2 space-y-2">
+						<label for="recurring-due-month" class="text-sm font-medium">Due month</label>
+						<Select.Root
+							type="single"
+							name="dueMonth"
+							value={String($form.dueMonth ?? '')}
+							onValueChange={(value) => ($form.dueMonth = value ? Number(value) : null)}
+						>
+							<Select.Trigger class="w-full {$errors.dueMonth ? 'border-red-400' : ''}">
+								{dueMonthLabel ? dueMonthLabel : 'Select a month'}
+							</Select.Trigger>
+							<Select.Content>
+								<Select.Label class="px-2 py-1 text-sm font-medium">Due month</Select.Label>
+								{#each months as month (month.value)}
+									<Select.Item value={month.value}>{month.label}</Select.Item>
+								{/each}
+							</Select.Content>
+						</Select.Root>
+						{#if $errors.dueMonth}
+							<p class="text-sm text-red-500">{$errors.dueMonth}</p>
+						{/if}
+					</div>
 				{/if}
 			</div>
 

--- a/src/lib/components/UpcomingBillsCard.svelte
+++ b/src/lib/components/UpcomingBillsCard.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import * as Separator from '$lib/components/ui/separator/index.js';
+	import type { Recurring } from '$lib/types';
+	import { formatCurrency } from '$lib/utils';
+	import { getCurrentPeriodDueDate, getDaysUntilDue } from '$lib/utils/dates';
+	import { CalendarClockIcon } from '@lucide/svelte/icons';
+
+	interface Props {
+		recurring: Recurring[];
+	}
+
+	let { recurring }: Props = $props();
+
+	const UPCOMING_WINDOW_DAYS = 14;
+
+	type UpcomingBill = { item: Recurring; daysUntilDue: number };
+
+	let upcoming = $derived.by<UpcomingBill[]>(() => {
+		const now = new Date();
+
+		return recurring
+			.filter((item) => !item.paid && item.dueDay != null)
+			.map((item) => ({
+				item,
+				daysUntilDue: getDaysUntilDue(
+					getCurrentPeriodDueDate(item.dueDay as number, item.dueMonth, item.cadence, now),
+					now
+				)
+			}))
+			.filter(({ daysUntilDue }) => daysUntilDue <= UPCOMING_WINDOW_DAYS)
+			.sort((a, b) => a.daysUntilDue - b.daysUntilDue);
+	});
+
+	function dueLabel(daysUntilDue: number): string {
+		if (daysUntilDue < 0) {
+			const overdueDays = Math.abs(daysUntilDue);
+			return `Overdue by ${overdueDays} day${overdueDays === 1 ? '' : 's'}`;
+		}
+		if (daysUntilDue === 0) return 'Due today';
+		if (daysUntilDue === 1) return 'Due tomorrow';
+		return `Due in ${daysUntilDue} days`;
+	}
+
+	function badgeClass(daysUntilDue: number): string {
+		if (daysUntilDue < 0) return 'bg-destructive hover:bg-destructive text-white';
+		if (daysUntilDue <= 1) return 'bg-amber-500 hover:bg-amber-500 text-white';
+		return 'bg-muted-foreground/30 hover:bg-muted-foreground/30 text-white';
+	}
+</script>
+
+<Card.Root>
+	<Card.Header class="pb-3">
+		<div class="flex items-center gap-2">
+			<CalendarClockIcon class="text-muted-foreground size-4" />
+			<Card.Title class="text-base">Upcoming Bills</Card.Title>
+		</div>
+	</Card.Header>
+	<Card.Content class="pt-0">
+		{#if upcoming.length === 0}
+			<p class="text-muted-foreground py-4 text-center text-sm">No bills due soon</p>
+		{:else}
+			<div class="max-h-72 overflow-y-auto">
+				{#each upcoming as { item, daysUntilDue }, i (item.id)}
+					{#if i > 0}
+						<Separator.Root class="my-0" />
+					{/if}
+					<div class="flex items-center justify-between py-2.5">
+						<p class="text-sm font-medium">{item.merchant}</p>
+						<div class="flex items-center gap-2">
+							<Badge class="text-xs {badgeClass(daysUntilDue)}">{dueLabel(daysUntilDue)}</Badge>
+							<span class="text-sm font-semibold tabular-nums">{formatCurrency(item.amount)}</span>
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</Card.Content>
+</Card.Root>

--- a/src/lib/formSchemas/finances.ts
+++ b/src/lib/formSchemas/finances.ts
@@ -28,19 +28,34 @@ export const incomeSchema = z.object({
 	amount: z.number().positive('Amount must be positive')
 });
 
-export const recurringSchema = z.object({
-	id: z.string().optional(),
-	amount: z.number().positive('Amount must be positive'),
-	description: z
-		.string()
-		.min(1, 'Description is required')
-		.max(500, 'Description must be at most 500 characters'),
-	merchant: z
-		.string()
-		.min(1, 'Merchant is required')
-		.max(100, 'Merchant must be at most 100 characters'),
-	cadence: z.string().min(1, 'Cadence is required').max(50, 'Cadence must be at most 50 characters')
-});
+export const recurringSchema = z
+	.object({
+		id: z.string().optional(),
+		amount: z.number().positive('Amount must be positive'),
+		description: z
+			.string()
+			.min(1, 'Description is required')
+			.max(500, 'Description must be at most 500 characters'),
+		merchant: z
+			.string()
+			.min(1, 'Merchant is required')
+			.max(100, 'Merchant must be at most 100 characters'),
+		cadence: z
+			.string()
+			.min(1, 'Cadence is required')
+			.max(50, 'Cadence must be at most 50 characters'),
+		dueDay: z.number().int().min(1).max(31).nullable().optional(),
+		dueMonth: z.number().int().min(1).max(12).nullable().optional()
+	})
+	.superRefine((data, ctx) => {
+		if (data.cadence === 'Yearly' && data.dueDay && !data.dueMonth) {
+			ctx.addIssue({
+				code: 'custom',
+				message: 'Due month is required for yearly cadence',
+				path: ['dueMonth']
+			});
+		}
+	});
 
 export const togglePaidSchema = z.object({
 	id: z.string().min(1, 'Recurring ID is required'),

--- a/src/lib/server/db/migrations/0008_bored_vulcan.sql
+++ b/src/lib/server/db/migrations/0008_bored_vulcan.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `recurring` ADD `due_day` integer;--> statement-breakpoint
+ALTER TABLE `recurring` ADD `due_month` integer;

--- a/src/lib/server/db/migrations/meta/0008_snapshot.json
+++ b/src/lib/server/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1592 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "58a21754-f51e-4bc9-9797-da3af3d99bba",
+	"prevId": "f9060d34-8e0e-4f87-abda-bf31d786a963",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_user_id_users_id_fk": {
+					"name": "account_user_id_users_id_fk",
+					"tableFrom": "account",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"budget": {
+			"name": "budget",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"month": {
+					"name": "month",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"year": {
+					"name": "year",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"preset_type": {
+					"name": "preset_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"category_id": {
+					"name": "category_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"budget_category_id_category_id_fk": {
+					"name": "budget_category_id_category_id_fk",
+					"tableFrom": "budget",
+					"tableTo": "category",
+					"columnsFrom": ["category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"budget_user_id_users_id_fk": {
+					"name": "budget_user_id_users_id_fk",
+					"tableFrom": "budget",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"budget_created_by_users_id_fk": {
+					"name": "budget_created_by_users_id_fk",
+					"tableFrom": "budget",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"budget_updated_by_users_id_fk": {
+					"name": "budget_updated_by_users_id_fk",
+					"tableFrom": "budget",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"category": {
+			"name": "category",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"category_created_by_users_id_fk": {
+					"name": "category_created_by_users_id_fk",
+					"tableFrom": "category",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"category_updated_by_users_id_fk": {
+					"name": "category_updated_by_users_id_fk",
+					"tableFrom": "category",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"contributions": {
+			"name": "contributions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"goal_id": {
+					"name": "goal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"contributions_goal_id_savings_goals_id_fk": {
+					"name": "contributions_goal_id_savings_goals_id_fk",
+					"tableFrom": "contributions",
+					"tableTo": "savings_goals",
+					"columnsFrom": ["goal_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"contributions_user_id_users_id_fk": {
+					"name": "contributions_user_id_users_id_fk",
+					"tableFrom": "contributions",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"contributions_created_by_users_id_fk": {
+					"name": "contributions_created_by_users_id_fk",
+					"tableFrom": "contributions",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"contributions_updated_by_users_id_fk": {
+					"name": "contributions_updated_by_users_id_fk",
+					"tableFrom": "contributions",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"income": {
+			"name": "income",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"income_user_id_users_id_fk": {
+					"name": "income_user_id_users_id_fk",
+					"tableFrom": "income",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"income_created_by_users_id_fk": {
+					"name": "income_created_by_users_id_fk",
+					"tableFrom": "income",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"income_updated_by_users_id_fk": {
+					"name": "income_updated_by_users_id_fk",
+					"tableFrom": "income",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"recurring": {
+			"name": "recurring",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"merchant": {
+					"name": "merchant",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cadence": {
+					"name": "cadence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"paid": {
+					"name": "paid",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"due_day": {
+					"name": "due_day",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"due_month": {
+					"name": "due_month",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"recurring_user_id_users_id_fk": {
+					"name": "recurring_user_id_users_id_fk",
+					"tableFrom": "recurring",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"recurring_created_by_users_id_fk": {
+					"name": "recurring_created_by_users_id_fk",
+					"tableFrom": "recurring",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"recurring_updated_by_users_id_fk": {
+					"name": "recurring_updated_by_users_id_fk",
+					"tableFrom": "recurring",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"savings": {
+			"name": "savings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"savings_user_id_users_id_fk": {
+					"name": "savings_user_id_users_id_fk",
+					"tableFrom": "savings",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"savings_created_by_users_id_fk": {
+					"name": "savings_created_by_users_id_fk",
+					"tableFrom": "savings",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"savings_updated_by_users_id_fk": {
+					"name": "savings_updated_by_users_id_fk",
+					"tableFrom": "savings",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"savings_goals": {
+			"name": "savings_goals",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_amount": {
+					"name": "target_amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_date": {
+					"name": "target_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"savings_goals_user_id_users_id_fk": {
+					"name": "savings_goals_user_id_users_id_fk",
+					"tableFrom": "savings_goals",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"savings_goals_created_by_users_id_fk": {
+					"name": "savings_goals_created_by_users_id_fk",
+					"tableFrom": "savings_goals",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"savings_goals_updated_by_users_id_fk": {
+					"name": "savings_goals_updated_by_users_id_fk",
+					"tableFrom": "savings_goals",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_users_id_fk": {
+					"name": "session_user_id_users_id_fk",
+					"tableFrom": "session",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"transactions": {
+			"name": "transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"payee": {
+					"name": "payee",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"gst_amount": {
+					"name": "gst_amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"excluded_from_budget": {
+					"name": "excluded_from_budget",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"category_id": {
+					"name": "category_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"transactions_category_id_category_id_fk": {
+					"name": "transactions_category_id_category_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "category",
+					"columnsFrom": ["category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_user_id_users_id_fk": {
+					"name": "transactions_user_id_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_created_by_users_id_fk": {
+					"name": "transactions_created_by_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_updated_by_users_id_fk": {
+					"name": "transactions_updated_by_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"window_cleaning_customers": {
+			"name": "window_cleaning_customers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"city": {
+					"name": "city",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"unit_number": {
+					"name": "unit_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"buzzer_number": {
+					"name": "buzzer_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phone_number": {
+					"name": "phone_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deleted_at": {
+					"name": "deleted_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deleted_by": {
+					"name": "deleted_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"window_cleaning_customers_deleted_by_users_id_fk": {
+					"name": "window_cleaning_customers_deleted_by_users_id_fk",
+					"tableFrom": "window_cleaning_customers",
+					"tableTo": "users",
+					"columnsFrom": ["deleted_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"window_cleaning_customers_user_id_users_id_fk": {
+					"name": "window_cleaning_customers_user_id_users_id_fk",
+					"tableFrom": "window_cleaning_customers",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"window_cleaning_customers_created_by_users_id_fk": {
+					"name": "window_cleaning_customers_created_by_users_id_fk",
+					"tableFrom": "window_cleaning_customers",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"window_cleaning_customers_updated_by_users_id_fk": {
+					"name": "window_cleaning_customers_updated_by_users_id_fk",
+					"tableFrom": "window_cleaning_customers",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"window_cleaning_jobs": {
+			"name": "window_cleaning_jobs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"job_date": {
+					"name": "job_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"job_time": {
+					"name": "job_time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"amount_charged": {
+					"name": "amount_charged",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tip": {
+					"name": "tip",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"duration_hours": {
+					"name": "duration_hours",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"window_cleaning_jobs_customer_id_window_cleaning_customers_id_fk": {
+					"name": "window_cleaning_jobs_customer_id_window_cleaning_customers_id_fk",
+					"tableFrom": "window_cleaning_jobs",
+					"tableTo": "window_cleaning_customers",
+					"columnsFrom": ["customer_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"window_cleaning_jobs_user_id_users_id_fk": {
+					"name": "window_cleaning_jobs_user_id_users_id_fk",
+					"tableFrom": "window_cleaning_jobs",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"window_cleaning_jobs_created_by_users_id_fk": {
+					"name": "window_cleaning_jobs_created_by_users_id_fk",
+					"tableFrom": "window_cleaning_jobs",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"window_cleaning_jobs_updated_by_users_id_fk": {
+					"name": "window_cleaning_jobs_updated_by_users_id_fk",
+					"tableFrom": "window_cleaning_jobs",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/src/lib/server/db/migrations/meta/_journal.json
+++ b/src/lib/server/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
 			"when": 1780441816364,
 			"tag": "0007_remarkable_krista_starr",
 			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "6",
+			"when": 1785715908228,
+			"tag": "0008_bored_vulcan",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/lib/server/db/schema/recurring.ts
+++ b/src/lib/server/db/schema/recurring.ts
@@ -11,6 +11,8 @@ const recurring = sqliteTable('recurring', {
 	cadence: text('cadence').notNull(),
 	amount: real('amount').notNull(),
 	paid: integer('paid', { mode: 'boolean' }).notNull().default(false),
+	dueDay: integer('due_day'),
+	dueMonth: integer('due_month'),
 	userId: text('user_id')
 		.notNull()
 		.references(() => user.id),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -81,6 +81,8 @@ export type Recurring = {
 	cadence: 'Monthly' | 'Yearly';
 	amount: number;
 	paid: boolean;
+	dueDay: number | null;
+	dueMonth: number | null;
 	user: User;
 };
 

--- a/src/lib/utils/dates.test.ts
+++ b/src/lib/utils/dates.test.ts
@@ -6,7 +6,9 @@ import {
 	formatLocalTimestamp,
 	formatTime12h,
 	getCalendarYearMonthsRange,
+	getCurrentPeriodDueDate,
 	getCurrentUTCTimestamp,
+	getDaysUntilDue,
 	getMonthDateRange,
 	getMonthProgress,
 	getMonthRangeFromUrl,
@@ -593,6 +595,55 @@ describe('Date Utilities - Local Timezone Storage', () => {
 				unit: 'month'
 			});
 			expect(progress.percentage).toBeCloseTo((2 / 12) * 100, 6);
+		});
+	});
+
+	describe('getCurrentPeriodDueDate', () => {
+		it('returns the due day in the current month for Monthly cadence', () => {
+			const dueDate = getCurrentPeriodDueDate(15, null, 'Monthly', new Date('2026-03-06T12:00:00'));
+			expect(dueDate).toEqual(new Date(2026, 2, 15));
+		});
+
+		it('clamps the due day to the last day of a short month', () => {
+			const dueDate = getCurrentPeriodDueDate(31, null, 'Monthly', new Date('2026-02-06T12:00:00'));
+			expect(dueDate).toEqual(new Date(2026, 1, 28));
+		});
+
+		it('clamps to Feb 29 in a leap year', () => {
+			const dueDate = getCurrentPeriodDueDate(31, null, 'Monthly', new Date('2024-02-06T12:00:00'));
+			expect(dueDate).toEqual(new Date(2024, 1, 29));
+		});
+
+		it('uses dueMonth for Yearly cadence', () => {
+			const dueDate = getCurrentPeriodDueDate(15, 3, 'Yearly', new Date('2026-01-06T12:00:00'));
+			expect(dueDate).toEqual(new Date(2026, 2, 15));
+		});
+
+		it('falls back to the current month for Yearly cadence when dueMonth is missing', () => {
+			const dueDate = getCurrentPeriodDueDate(15, null, 'Yearly', new Date('2026-01-06T12:00:00'));
+			expect(dueDate).toEqual(new Date(2026, 0, 15));
+		});
+	});
+
+	describe('getDaysUntilDue', () => {
+		it('returns 0 when the due date is today', () => {
+			const referenceDate = new Date('2026-03-06T18:00:00');
+			expect(getDaysUntilDue(new Date(2026, 2, 6), referenceDate)).toBe(0);
+		});
+
+		it('returns a positive count for a future due date', () => {
+			const referenceDate = new Date('2026-03-06T12:00:00');
+			expect(getDaysUntilDue(new Date(2026, 2, 15), referenceDate)).toBe(9);
+		});
+
+		it('returns a negative count for a past due date (overdue)', () => {
+			const referenceDate = new Date('2026-03-15T12:00:00');
+			expect(getDaysUntilDue(new Date(2026, 2, 6), referenceDate)).toBe(-9);
+		});
+
+		it('ignores the time-of-day component', () => {
+			const referenceDate = new Date('2026-03-06T23:59:00');
+			expect(getDaysUntilDue(new Date(2026, 2, 7, 0, 1), referenceDate)).toBe(1);
 		});
 	});
 });

--- a/src/lib/utils/dates.ts
+++ b/src/lib/utils/dates.ts
@@ -361,3 +361,42 @@ export function getYearProgress(year: number, referenceDate: Date = new Date()):
 
 	return buildPeriodProgress('year', referenceDate.getMonth(), totalUnits, 'current', 'month');
 }
+
+function getLastDayOfMonth(year: number, month: number): number {
+	return new Date(year, month, 0).getDate();
+}
+
+/**
+ * Get the due date within the current cadence period for a recurring item.
+ * Monthly items are due on `dueDay` of the current month; Yearly items are due
+ * on `dueDay` of `dueMonth` in the current year. `dueDay` is clamped to the
+ * last day of the target month (e.g. dueDay=31 in February → Feb 28/29).
+ */
+export function getCurrentPeriodDueDate(
+	dueDay: number,
+	dueMonth: number | null,
+	cadence: string,
+	referenceDate: Date = new Date()
+): Date {
+	const year = referenceDate.getFullYear();
+	const month = cadence === 'Yearly' && dueMonth ? dueMonth : referenceDate.getMonth() + 1;
+	const day = Math.min(dueDay, getLastDayOfMonth(year, month));
+
+	return new Date(year, month - 1, day);
+}
+
+/**
+ * Get the signed number of days between a due date and the reference date.
+ * Negative values mean the due date has passed (overdue).
+ */
+export function getDaysUntilDue(dueDate: Date, referenceDate: Date = new Date()): number {
+	const startOfDue = new Date(dueDate.getFullYear(), dueDate.getMonth(), dueDate.getDate());
+	const startOfReference = new Date(
+		referenceDate.getFullYear(),
+		referenceDate.getMonth(),
+		referenceDate.getDate()
+	);
+	const msPerDay = 24 * 60 * 60 * 1000;
+
+	return Math.round((startOfDue.getTime() - startOfReference.getTime()) / msPerDay);
+}

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -23,6 +23,7 @@
 	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
 	import * as Select from '$lib/components/ui/select/index.js';
 	import * as Tabs from '$lib/components/ui/tabs/index.js';
+	import UpcomingBillsCard from '$lib/components/UpcomingBillsCard.svelte';
 	import WindowCleaningSummaryCard from '$lib/components/WindowCleaningSummaryCard.svelte';
 	import { getCategoriesContext } from '$lib/contexts';
 	import { formatCurrency, monthNames, months } from '$lib/utils';
@@ -574,6 +575,11 @@
 				chartTitle="Income vs Spending"
 				chartDescription="6-month trend"
 			/>
+		</div>
+
+		<!-- Upcoming bills -->
+		<div class="mb-6">
+			<UpcomingBillsCard recurring={data.recurringExpenses || []} />
 		</div>
 
 		<!-- Recurring expenses card -->

--- a/src/routes/(app)/recurring/+page.server.ts
+++ b/src/routes/(app)/recurring/+page.server.ts
@@ -34,13 +34,17 @@ export const actions = {
 			description: data.description,
 			merchant: data.merchant,
 			cadence: data.cadence,
+			dueDay: data.dueDay ?? null,
+			dueMonth: data.dueMonth ?? null,
 			userId
 		}),
 		transformUpdate: (data) => ({
 			amount: data.amount,
 			description: data.description,
 			merchant: data.merchant,
-			cadence: data.cadence
+			cadence: data.cadence,
+			dueDay: data.dueDay ?? null,
+			dueMonth: data.dueMonth ?? null
 		})
 	}),
 	togglePaid: requireAuth(async ({ request }, user) => {

--- a/src/routes/(app)/recurring/columns.ts
+++ b/src/routes/(app)/recurring/columns.ts
@@ -6,6 +6,36 @@ import { createRawSnippet } from 'svelte';
 
 import DataTableActions from './data-table-actions.svelte';
 
+const MONTH_ABBREVIATIONS = [
+	'Jan',
+	'Feb',
+	'Mar',
+	'Apr',
+	'May',
+	'Jun',
+	'Jul',
+	'Aug',
+	'Sep',
+	'Oct',
+	'Nov',
+	'Dec'
+];
+
+function formatDueDate(recurring: Recurring): string {
+	if (!recurring.dueDay) return '—';
+	if (recurring.cadence === 'Yearly' && recurring.dueMonth) {
+		return `${MONTH_ABBREVIATIONS[recurring.dueMonth - 1]} ${recurring.dueDay}`;
+	}
+	return `${recurring.dueDay}${ordinalSuffix(recurring.dueDay)}`;
+}
+
+function ordinalSuffix(day: number): string {
+	if (day % 10 === 1 && day !== 11) return 'st';
+	if (day % 10 === 2 && day !== 12) return 'nd';
+	if (day % 10 === 3 && day !== 13) return 'rd';
+	return 'th';
+}
+
 export const columns: ColumnDef<Recurring>[] = [
 	{
 		accessorKey: 'merchant',
@@ -26,6 +56,20 @@ export const columns: ColumnDef<Recurring>[] = [
 	{
 		accessorKey: 'cadence',
 		header: 'Cadence'
+	},
+	{
+		id: 'dueDate',
+		header: 'Due',
+		cell: ({ row }) => {
+			const dueDateSnippet = createRawSnippet<[string]>((getDue) => {
+				const due = getDue();
+				return {
+					render: () => `<div>${due}</div>`
+				};
+			});
+
+			return renderSnippet(dueDateSnippet, formatDueDate(row.original));
+		}
 	},
 	{
 		accessorKey: 'amount',


### PR DESCRIPTION
## Summary
- Add nullable `dueDay`/`dueMonth` columns to `recurring`, so Monthly bills track a day-of-month and Yearly bills track a month + day.
- Add an "Upcoming Bills" dashboard widget (monthly view) showing unpaid items due within 14 days, sorted soonest/most-overdue first, alongside the existing exhaustive `RecurringExpensesCard`.
- Due-date math (`getCurrentPeriodDueDate` / `getDaysUntilDue` in `src/lib/utils/dates.ts`) is computed on the fly from `(dueDay, dueMonth, cadence, today)` — no cron rollover needed, so `runResetRecurringPaid` is untouched.
- `paid` remains a manual toggle; auto-deriving it from matching transactions is out of scope (flagged in the issue as a separate decision).

Closes #314

## Test plan
- [x] `npm run check` (svelte-check) — clean
- [x] `oxlint` — clean
- [x] `npm run test:unit` — 333/333 passing (9 new tests for the due-date utilities)
- [x] Migration `0008_bored_vulcan.sql` generated via `drizzle-kit generate` and applied locally
- [x] Manual click-through in browser (create Monthly/Yearly recurring items with due dates, confirm dashboard widget) — not yet done, browser automation was unavailable in the authoring session

🤖 Generated with [Claude Code](https://claude.com/claude-code)