### PR TITLE
Dashboard anomaly insights, section visibility, and quick actions

### DIFF
--- a/src/lib/components/CategoryAnomalyAlert.svelte
+++ b/src/lib/components/CategoryAnomalyAlert.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import type { CategoryAnomaly } from '$lib/types';
+	import { TrendingUpIcon } from '@lucide/svelte/icons';
+
+	interface Props {
+		anomalies: CategoryAnomaly[];
+		onViewCategory: (categoryId: string) => void;
+	}
+
+	let { anomalies, onViewCategory }: Props = $props();
+</script>
+
+{#if anomalies.length > 0}
+	<Card.Root class="border-amber-500/40 bg-amber-500/5">
+		<Card.Content class="px-4 py-3">
+			<div class="flex flex-wrap items-center gap-3">
+				<div class="flex shrink-0 items-center gap-2">
+					<TrendingUpIcon class="size-4 text-amber-600 dark:text-amber-400" />
+					<Badge
+						variant="outline"
+						class="border-amber-500/40 text-xs text-amber-700 dark:text-amber-400"
+					>
+						{anomalies.length}
+						{anomalies.length === 1 ? 'category' : 'categories'} unusually high
+					</Badge>
+				</div>
+				<div class="flex flex-wrap gap-2">
+					{#each anomalies as anomaly (anomaly.categoryId)}
+						<button
+							onclick={() => onViewCategory(anomaly.categoryId)}
+							class="flex items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-500/20 dark:text-amber-400"
+						>
+							{anomaly.categoryName}
+							<span class="font-bold">+{anomaly.percentOver}% vs avg</span>
+						</button>
+					{/each}
+				</div>
+			</div>
+		</Card.Content>
+	</Card.Root>
+{/if}

--- a/src/lib/components/DashboardCustomizePopover.svelte
+++ b/src/lib/components/DashboardCustomizePopover.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import * as Popover from '$lib/components/ui/popover/index.js';
+	import type { DashboardSectionDefinition } from '$lib/dashboardSections';
+	import type { dashboardVisibilitySchema } from '$lib/formSchemas';
+	import { SlidersHorizontalIcon } from '@lucide/svelte/icons';
+	import { toast } from 'svelte-sonner';
+	import type { SuperValidated } from 'sveltekit-superforms';
+	import { superForm } from 'sveltekit-superforms';
+	import type { z } from 'zod';
+
+	interface Props {
+		sections: DashboardSectionDefinition[];
+		dashboardVisibilityForm: SuperValidated<z.infer<typeof dashboardVisibilitySchema>>;
+	}
+
+	let { sections, dashboardVisibilityForm }: Props = $props();
+
+	let open = $state(false);
+
+	const formInstance = $derived(
+		superForm(dashboardVisibilityForm, {
+			dataType: 'json',
+			resetForm: false,
+			onUpdate: ({ form }) => {
+				// Read form.message, not $message: superforms clears the store on submit and only
+				// repopulates it after onUpdate has run, so the store is always undefined here.
+				if (form.message?.type === 'success') {
+					open = false;
+				} else if (form.message?.type === 'error') {
+					toast.error(form.message.text);
+				}
+			},
+			onError: ({ result }) => {
+				toast.error(
+					`There was an error saving your dashboard preferences: ${result.error.message}`
+				);
+			}
+		})
+	);
+
+	const { form, enhance, submitting } = $derived(formInstance);
+
+	function toggleSection(key: string, hidden: boolean) {
+		if (hidden) {
+			if (!$form.hiddenSections.includes(key)) {
+				$form.hiddenSections = [...$form.hiddenSections, key];
+			}
+		} else {
+			$form.hiddenSections = $form.hiddenSections.filter((k) => k !== key);
+		}
+	}
+</script>
+
+<Popover.Root bind:open>
+	<Popover.Trigger>
+		{#snippet child({ props })}
+			<Button {...props} variant="outline" size="sm" class="gap-2">
+				<SlidersHorizontalIcon class="size-4" />
+				Customize
+			</Button>
+		{/snippet}
+	</Popover.Trigger>
+	<Popover.Content class="w-72" align="end">
+		<form method="POST" action="?/updateVisibility" use:enhance class="space-y-3">
+			<p class="text-sm font-medium">Dashboard sections</p>
+			<div class="space-y-2">
+				{#each sections as section (section.key)}
+					<label class="flex items-center gap-2 text-sm">
+						<Checkbox
+							checked={!$form.hiddenSections.includes(section.key)}
+							onCheckedChange={(checked) => toggleSection(section.key, !checked)}
+						/>
+						{section.label}
+					</label>
+				{/each}
+			</div>
+			<Button type="submit" size="sm" class="w-full" disabled={$submitting}>
+				{$submitting ? 'Saving...' : 'Save'}
+			</Button>
+		</form>
+	</Popover.Content>
+</Popover.Root>

--- a/src/lib/components/UpcomingBillsCard.svelte
+++ b/src/lib/components/UpcomingBillsCard.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
+	import { enhance } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
 	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import * as Separator from '$lib/components/ui/separator/index.js';
 	import type { Recurring } from '$lib/types';
 	import { formatCurrency } from '$lib/utils';
+	import { actionMessage } from '$lib/utils/actionMessage';
 	import { getCurrentPeriodDueDate, getDaysUntilDue } from '$lib/utils/dates';
 	import { CalendarClockIcon } from '@lucide/svelte/icons';
+	import { toast } from 'svelte-sonner';
 
 	interface Props {
 		recurring: Recurring[];
@@ -32,6 +37,8 @@
 			.filter(({ daysUntilDue }) => daysUntilDue <= UPCOMING_WINDOW_DAYS)
 			.sort((a, b) => a.daysUntilDue - b.daysUntilDue);
 	});
+
+	let togglingId = $state<string | null>(null);
 
 	function dueLabel(daysUntilDue: number): string {
 		if (daysUntilDue < 0) {
@@ -66,11 +73,43 @@
 					{#if i > 0}
 						<Separator.Root class="my-0" />
 					{/if}
-					<div class="flex items-center justify-between py-2.5">
+					<div class="flex flex-wrap items-center justify-between gap-2 py-2.5">
 						<p class="text-sm font-medium">{item.merchant}</p>
 						<div class="flex items-center gap-2">
 							<Badge class="text-xs {badgeClass(daysUntilDue)}">{dueLabel(daysUntilDue)}</Badge>
 							<span class="text-sm font-semibold tabular-nums">{formatCurrency(item.amount)}</span>
+							<form
+								method="POST"
+								action="/recurring?/togglePaid"
+								use:enhance={() => {
+									togglingId = item.id;
+									return async ({ result, update }) => {
+										if (result.type === 'success') {
+											await invalidateAll();
+										} else {
+											const { text } = actionMessage(result, {
+												success: 'Marked as paid',
+												error: 'Failed to mark as paid'
+											});
+											toast.error(text);
+										}
+										await update();
+										togglingId = null;
+									};
+								}}
+							>
+								<input type="hidden" name="id" value={item.id} />
+								<input type="hidden" name="paid" value="true" />
+								<Button
+									type="submit"
+									size="sm"
+									variant="outline"
+									class="h-7 px-2 text-xs"
+									disabled={togglingId === item.id}
+								>
+									{togglingId === item.id ? 'Saving...' : 'Mark Paid'}
+								</Button>
+							</form>
 						</div>
 					</div>
 				{/each}

--- a/src/lib/components/ui/sidebar/sidebar-inset.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-inset.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	data-slot="sidebar-inset"
 	class={cn(
-		'relative flex w-full flex-1 flex-col bg-background',
+		'relative flex w-full min-w-0 flex-1 flex-col bg-background',
 		'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2',
 		className
 	)}

--- a/src/lib/dashboardSections.ts
+++ b/src/lib/dashboardSections.ts
@@ -1,0 +1,27 @@
+type DashboardSectionMode = 'monthly' | 'yearly' | 'both';
+
+export type DashboardSectionDefinition = {
+	key: string;
+	label: string;
+	mode: DashboardSectionMode;
+};
+
+const dashboardSections: DashboardSectionDefinition[] = [
+	{ key: 'safeToSpendHero', label: 'Safe-to-spend hero band', mode: 'monthly' },
+	{ key: 'kpiRow', label: 'KPI sparkline row', mode: 'monthly' },
+	{ key: 'monthlyOverview', label: 'Monthly overview & spending breakdown', mode: 'monthly' },
+	{ key: 'cashFlowProjection', label: 'Cash flow projection', mode: 'monthly' },
+	{ key: 'categoryOverview', label: 'Category overview (top at-risk)', mode: 'monthly' },
+	{ key: 'upcomingBills', label: 'Upcoming bills', mode: 'monthly' },
+	{ key: 'recurringExpenses', label: 'Recurring expenses', mode: 'monthly' },
+	{ key: 'allCategories', label: 'All categories', mode: 'monthly' },
+	{ key: 'ytdStats', label: 'Year-to-date stats', mode: 'yearly' },
+	{ key: 'netSavingsTable', label: 'Net savings table', mode: 'yearly' },
+	{ key: 'trendCharts', label: 'Trend charts', mode: 'yearly' },
+	{ key: 'spentByCategory', label: 'Spent by category', mode: 'yearly' },
+	{ key: 'goalsStrip', label: 'Savings goals strip', mode: 'both' }
+];
+
+export function dashboardSectionsForMode(mode: 'monthly' | 'yearly'): DashboardSectionDefinition[] {
+	return dashboardSections.filter((section) => section.mode === mode || section.mode === 'both');
+}

--- a/src/lib/formSchemas/dashboard.ts
+++ b/src/lib/formSchemas/dashboard.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const dashboardVisibilitySchema = z.object({
+	hiddenSections: z.array(z.string()).default([])
+});

--- a/src/lib/formSchemas/index.ts
+++ b/src/lib/formSchemas/index.ts
@@ -11,6 +11,7 @@ export {
 export { budgetSchema } from './budget';
 export { categorySchema } from './categories';
 export { idSchema } from './common';
+export { dashboardVisibilitySchema } from './dashboard';
 export { incomeSchema, recurringSchema, transactionSchema } from './finances';
 export { contributionSchema, savingsGoalSchema, savingsSchema, unArchiveSchema } from './savings';
 export {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,6 +6,7 @@ export type {
 	Budget,
 	CardType,
 	Category,
+	CategoryAnomaly,
 	ChartData,
 	Contribution,
 	ExcludedSpendCategory,

--- a/src/lib/server/db/migrations/0009_icy_king_cobra.sql
+++ b/src/lib/server/db/migrations/0009_icy_king_cobra.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `dashboard_section_preference` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`section_key` text NOT NULL,
+	`created_at` text DEFAULT (current_timestamp) NOT NULL,
+	`updated_at` text DEFAULT (current_timestamp) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `dashboard_section_preference_user_section_idx` ON `dashboard_section_preference` (`user_id`,`section_key`);

--- a/src/lib/server/db/migrations/meta/0009_snapshot.json
+++ b/src/lib/server/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,1655 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "f8ef3f2d-c771-43d6-9791-643120ed51ec",
+	"prevId": "58a21754-f51e-4bc9-9797-da3af3d99bba",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_user_id_users_id_fk": {
+					"name": "account_user_id_users_id_fk",
+					"tableFrom": "account",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"budget": {
+			"name": "budget",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"month": {
+					"name": "month",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"year": {
+					"name": "year",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"preset_type": {
+					"name": "preset_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"category_id": {
+					"name": "category_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"budget_category_id_category_id_fk": {
+					"name": "budget_category_id_category_id_fk",
+					"tableFrom": "budget",
+					"tableTo": "category",
+					"columnsFrom": ["category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"budget_user_id_users_id_fk": {
+					"name": "budget_user_id_users_id_fk",
+					"tableFrom": "budget",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"budget_created_by_users_id_fk": {
+					"name": "budget_created_by_users_id_fk",
+					"tableFrom": "budget",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"budget_updated_by_users_id_fk": {
+					"name": "budget_updated_by_users_id_fk",
+					"tableFrom": "budget",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"category": {
+			"name": "category",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"category_created_by_users_id_fk": {
+					"name": "category_created_by_users_id_fk",
+					"tableFrom": "category",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"category_updated_by_users_id_fk": {
+					"name": "category_updated_by_users_id_fk",
+					"tableFrom": "category",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"contributions": {
+			"name": "contributions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"goal_id": {
+					"name": "goal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"contributions_goal_id_savings_goals_id_fk": {
+					"name": "contributions_goal_id_savings_goals_id_fk",
+					"tableFrom": "contributions",
+					"tableTo": "savings_goals",
+					"columnsFrom": ["goal_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"contributions_user_id_users_id_fk": {
+					"name": "contributions_user_id_users_id_fk",
+					"tableFrom": "contributions",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"contributions_created_by_users_id_fk": {
+					"name": "contributions_created_by_users_id_fk",
+					"tableFrom": "contributions",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"contributions_updated_by_users_id_fk": {
+					"name": "contributions_updated_by_users_id_fk",
+					"tableFrom": "contributions",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"dashboard_section_preference": {
+			"name": "dashboard_section_preference",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"section_key": {
+					"name": "section_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				}
+			},
+			"indexes": {
+				"dashboard_section_preference_user_section_idx": {
+					"name": "dashboard_section_preference_user_section_idx",
+					"columns": ["user_id", "section_key"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"dashboard_section_preference_user_id_users_id_fk": {
+					"name": "dashboard_section_preference_user_id_users_id_fk",
+					"tableFrom": "dashboard_section_preference",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"income": {
+			"name": "income",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"income_user_id_users_id_fk": {
+					"name": "income_user_id_users_id_fk",
+					"tableFrom": "income",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"income_created_by_users_id_fk": {
+					"name": "income_created_by_users_id_fk",
+					"tableFrom": "income",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"income_updated_by_users_id_fk": {
+					"name": "income_updated_by_users_id_fk",
+					"tableFrom": "income",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"recurring": {
+			"name": "recurring",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"merchant": {
+					"name": "merchant",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cadence": {
+					"name": "cadence",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"paid": {
+					"name": "paid",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"due_day": {
+					"name": "due_day",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"due_month": {
+					"name": "due_month",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"recurring_user_id_users_id_fk": {
+					"name": "recurring_user_id_users_id_fk",
+					"tableFrom": "recurring",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"recurring_created_by_users_id_fk": {
+					"name": "recurring_created_by_users_id_fk",
+					"tableFrom": "recurring",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"recurring_updated_by_users_id_fk": {
+					"name": "recurring_updated_by_users_id_fk",
+					"tableFrom": "recurring",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"savings": {
+			"name": "savings",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"savings_user_id_users_id_fk": {
+					"name": "savings_user_id_users_id_fk",
+					"tableFrom": "savings",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"savings_created_by_users_id_fk": {
+					"name": "savings_created_by_users_id_fk",
+					"tableFrom": "savings",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"savings_updated_by_users_id_fk": {
+					"name": "savings_updated_by_users_id_fk",
+					"tableFrom": "savings",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"savings_goals": {
+			"name": "savings_goals",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_amount": {
+					"name": "target_amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_date": {
+					"name": "target_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"savings_goals_user_id_users_id_fk": {
+					"name": "savings_goals_user_id_users_id_fk",
+					"tableFrom": "savings_goals",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"savings_goals_created_by_users_id_fk": {
+					"name": "savings_goals_created_by_users_id_fk",
+					"tableFrom": "savings_goals",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"savings_goals_updated_by_users_id_fk": {
+					"name": "savings_goals_updated_by_users_id_fk",
+					"tableFrom": "savings_goals",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_users_id_fk": {
+					"name": "session_user_id_users_id_fk",
+					"tableFrom": "session",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"transactions": {
+			"name": "transactions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"amount": {
+					"name": "amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"payee": {
+					"name": "payee",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"gst_amount": {
+					"name": "gst_amount",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"excluded_from_budget": {
+					"name": "excluded_from_budget",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"category_id": {
+					"name": "category_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"transactions_category_id_category_id_fk": {
+					"name": "transactions_category_id_category_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "category",
+					"columnsFrom": ["category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_user_id_users_id_fk": {
+					"name": "transactions_user_id_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_created_by_users_id_fk": {
+					"name": "transactions_created_by_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"transactions_updated_by_users_id_fk": {
+					"name": "transactions_updated_by_users_id_fk",
+					"tableFrom": "transactions",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"window_cleaning_customers": {
+			"name": "window_cleaning_customers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"address": {
+					"name": "address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"city": {
+					"name": "city",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"unit_number": {
+					"name": "unit_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"buzzer_number": {
+					"name": "buzzer_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"phone_number": {
+					"name": "phone_number",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deleted_at": {
+					"name": "deleted_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deleted_by": {
+					"name": "deleted_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"window_cleaning_customers_deleted_by_users_id_fk": {
+					"name": "window_cleaning_customers_deleted_by_users_id_fk",
+					"tableFrom": "window_cleaning_customers",
+					"tableTo": "users",
+					"columnsFrom": ["deleted_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"window_cleaning_customers_user_id_users_id_fk": {
+					"name": "window_cleaning_customers_user_id_users_id_fk",
+					"tableFrom": "window_cleaning_customers",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"window_cleaning_customers_created_by_users_id_fk": {
+					"name": "window_cleaning_customers_created_by_users_id_fk",
+					"tableFrom": "window_cleaning_customers",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"window_cleaning_customers_updated_by_users_id_fk": {
+					"name": "window_cleaning_customers_updated_by_users_id_fk",
+					"tableFrom": "window_cleaning_customers",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"window_cleaning_jobs": {
+			"name": "window_cleaning_jobs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"job_date": {
+					"name": "job_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"job_time": {
+					"name": "job_time",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"amount_charged": {
+					"name": "amount_charged",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tip": {
+					"name": "tip",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"duration_hours": {
+					"name": "duration_hours",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(current_timestamp)"
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"window_cleaning_jobs_customer_id_window_cleaning_customers_id_fk": {
+					"name": "window_cleaning_jobs_customer_id_window_cleaning_customers_id_fk",
+					"tableFrom": "window_cleaning_jobs",
+					"tableTo": "window_cleaning_customers",
+					"columnsFrom": ["customer_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"window_cleaning_jobs_user_id_users_id_fk": {
+					"name": "window_cleaning_jobs_user_id_users_id_fk",
+					"tableFrom": "window_cleaning_jobs",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"window_cleaning_jobs_created_by_users_id_fk": {
+					"name": "window_cleaning_jobs_created_by_users_id_fk",
+					"tableFrom": "window_cleaning_jobs",
+					"tableTo": "users",
+					"columnsFrom": ["created_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"window_cleaning_jobs_updated_by_users_id_fk": {
+					"name": "window_cleaning_jobs_updated_by_users_id_fk",
+					"tableFrom": "window_cleaning_jobs",
+					"tableTo": "users",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/src/lib/server/db/migrations/meta/_journal.json
+++ b/src/lib/server/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
 			"when": 1785715908228,
 			"tag": "0008_bored_vulcan",
 			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "6",
+			"when": 1785861978287,
+			"tag": "0009_icy_king_cobra",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/lib/server/db/queries/dashboardPreferences.ts
+++ b/src/lib/server/db/queries/dashboardPreferences.ts
@@ -1,0 +1,34 @@
+import { eq } from 'drizzle-orm';
+
+import { getDb } from '../index';
+import { dashboardSectionPreference } from '../schema';
+
+export const dashboardPreferenceQueries = {
+	findHiddenKeysByUserId: async (userId: string): Promise<string[]> => {
+		const rows = await getDb()
+			.select({ sectionKey: dashboardSectionPreference.sectionKey })
+			.from(dashboardSectionPreference)
+			.where(eq(dashboardSectionPreference.userId, userId));
+
+		return rows.map((row) => row.sectionKey);
+	},
+
+	// Replaces the full hidden-section set for a user in one go (delete-all-then-insert) —
+	// simpler and just as correct as a per-key upsert since the client always submits the
+	// complete set of currently-hidden keys.
+	setHiddenKeys: async (userId: string, sectionKeys: string[]): Promise<void> => {
+		const db = getDb();
+
+		db.transaction((tx) => {
+			tx.delete(dashboardSectionPreference)
+				.where(eq(dashboardSectionPreference.userId, userId))
+				.run();
+
+			if (sectionKeys.length > 0) {
+				tx.insert(dashboardSectionPreference)
+					.values(sectionKeys.map((sectionKey) => ({ userId, sectionKey })))
+					.run();
+			}
+		});
+	}
+};

--- a/src/lib/server/db/queries/index.ts
+++ b/src/lib/server/db/queries/index.ts
@@ -1,5 +1,6 @@
 export { budgetQueries } from './budgets';
 export { categoryQueries } from './categories';
+export { dashboardPreferenceQueries } from './dashboardPreferences';
 export { incomeQueries } from './income';
 export { recurringQueries } from './recurring';
 export { savingsQueries } from './savings';

--- a/src/lib/server/db/schema/dashboardSectionPreference.ts
+++ b/src/lib/server/db/schema/dashboardSectionPreference.ts
@@ -1,0 +1,36 @@
+import { relations, sql } from 'drizzle-orm';
+import { sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
+
+import { generateId } from '../utils';
+import user from './user';
+
+const dashboardSectionPreference = sqliteTable(
+	'dashboard_section_preference',
+	{
+		id: text('id').primaryKey().$defaultFn(generateId),
+		userId: text('user_id')
+			.notNull()
+			.references(() => user.id, { onDelete: 'cascade' }),
+		// Presence of a row means this section is hidden for this user (opt-out model),
+		// so sections added later default to visible with no backfill needed.
+		sectionKey: text('section_key').notNull(),
+		createdAt: text('created_at')
+			.notNull()
+			.default(sql`(current_timestamp)`),
+		updatedAt: text('updated_at')
+			.notNull()
+			.default(sql`(current_timestamp)`)
+	},
+	(table) => [
+		uniqueIndex('dashboard_section_preference_user_section_idx').on(table.userId, table.sectionKey)
+	]
+);
+
+export const dashboardSectionPreferenceRelations = relations(
+	dashboardSectionPreference,
+	({ one }) => ({
+		user: one(user, { fields: [dashboardSectionPreference.userId], references: [user.id] })
+	})
+);
+
+export default dashboardSectionPreference;

--- a/src/lib/server/db/schema/index.ts
+++ b/src/lib/server/db/schema/index.ts
@@ -2,6 +2,10 @@ export { default as account, accountRelations } from './account';
 export { default as budget, budgetRelations } from './budget';
 export { default as category } from './category';
 export { default as contribution, contributionRelations } from './contribution';
+export {
+	default as dashboardSectionPreference,
+	dashboardSectionPreferenceRelations
+} from './dashboardSectionPreference';
 export { default as income } from './income';
 export { default as recurring, recurringRelations } from './recurring';
 export { default as savings, savingsRelations } from './savings';

--- a/src/lib/server/insights/category-anomalies.test.ts
+++ b/src/lib/server/insights/category-anomalies.test.ts
@@ -1,0 +1,140 @@
+import type { Transaction, User } from '$lib/types';
+import { describe, expect, it } from 'vitest';
+
+import { computeCategoryAnomalies, type HistoricalMonthRange } from './category-anomalies';
+
+const fixtureUser: User = {
+	id: 'user-1',
+	name: 'Test User',
+	email: 'test@example.com',
+	emailVerified: true,
+	createdAt: '2026-01-01',
+	updatedAt: '2026-01-01'
+};
+
+function buildTx(
+	categoryId: string,
+	categoryName: string,
+	amount: number,
+	date: string
+): Transaction {
+	return {
+		id: `${categoryId}-${date}`,
+		amount,
+		payee: 'Test Payee',
+		notes: '',
+		date,
+		gstAmount: null,
+		excludedFromBudget: false,
+		category: { id: categoryId, name: categoryName, description: '', createdAt: '', updatedAt: '' },
+		user: fixtureUser
+	};
+}
+
+// Jan-Jun 2026, with June as the "current" month.
+const sixMonthRange: HistoricalMonthRange[] = [
+	{ monthStart: '2026-01-01', monthEnd: '2026-01-31' },
+	{ monthStart: '2026-02-01', monthEnd: '2026-02-28' },
+	{ monthStart: '2026-03-01', monthEnd: '2026-03-31' },
+	{ monthStart: '2026-04-01', monthEnd: '2026-04-30' },
+	{ monthStart: '2026-05-01', monthEnd: '2026-05-31' },
+	{ monthStart: '2026-06-01', monthEnd: '2026-06-30' }
+];
+
+const priorMonthStarts = sixMonthRange.slice(0, -1).map((range) => range.monthStart);
+
+function buildPriorMonthsSpend(
+	categoryId: string,
+	categoryName: string,
+	amount: number
+): Transaction[] {
+	return priorMonthStarts.map((monthStart) =>
+		buildTx(categoryId, categoryName, amount, monthStart)
+	);
+}
+
+describe('computeCategoryAnomalies', () => {
+	it('flags a category spending more than 25% over its trailing average', () => {
+		const transactions = [
+			...buildPriorMonthsSpend('groceries', 'Groceries', 100),
+			buildTx('groceries', 'Groceries', 140, '2026-06-15')
+		];
+
+		const anomalies = computeCategoryAnomalies(transactions, sixMonthRange);
+
+		expect(anomalies).toEqual([
+			{
+				categoryId: 'groceries',
+				categoryName: 'Groceries',
+				currentAmount: 140,
+				trailingAverage: 100,
+				percentOver: 40
+			}
+		]);
+	});
+
+	it('does not flag a category within 25% of its trailing average', () => {
+		const transactions = [
+			...buildPriorMonthsSpend('dining', 'Dining Out', 100),
+			buildTx('dining', 'Dining Out', 120, '2026-06-15')
+		];
+
+		expect(computeCategoryAnomalies(transactions, sixMonthRange)).toEqual([]);
+	});
+
+	it('ignores categories whose trailing average is below the minimum baseline', () => {
+		const transactions = [
+			...buildPriorMonthsSpend('parking', 'Parking', 10),
+			buildTx('parking', 'Parking', 50, '2026-06-15')
+		];
+
+		expect(computeCategoryAnomalies(transactions, sixMonthRange)).toEqual([]);
+	});
+
+	it('returns no anomalies when there is not enough prior-month history', () => {
+		const shortRange = sixMonthRange.slice(-3); // only 2 prior months
+		const transactions = [
+			buildTx('groceries', 'Groceries', 100, '2026-04-15'),
+			buildTx('groceries', 'Groceries', 100, '2026-05-15'),
+			buildTx('groceries', 'Groceries', 500, '2026-06-15')
+		];
+
+		expect(computeCategoryAnomalies(transactions, shortRange)).toEqual([]);
+	});
+
+	it('ignores transactions with no category', () => {
+		const transactions: Transaction[] = [
+			...buildPriorMonthsSpend('groceries', 'Groceries', 100).map((tx) => ({
+				...tx,
+				category: null
+			})),
+			{ ...buildTx('groceries', 'Groceries', 200, '2026-06-15'), category: null }
+		];
+
+		expect(computeCategoryAnomalies(transactions, sixMonthRange)).toEqual([]);
+	});
+
+	it('sorts by percent-over descending and caps at 5 results', () => {
+		const transactions = Array.from({ length: 6 }, (_, i) => {
+			const categoryId = `cat-${i}`;
+			// Trailing average of 50, current spend increasing with i so percentOver descends as i increases: cat-0 is highest.
+			const currentAmount = 150 - i * 10;
+			return [
+				...buildPriorMonthsSpend(categoryId, `Category ${i}`, 50),
+				buildTx(categoryId, `Category ${i}`, currentAmount, '2026-06-15')
+			];
+		}).flat();
+
+		const anomalies = computeCategoryAnomalies(transactions, sixMonthRange);
+
+		expect(anomalies).toHaveLength(5);
+		expect(anomalies.map((a) => a.categoryId)).toEqual([
+			'cat-0',
+			'cat-1',
+			'cat-2',
+			'cat-3',
+			'cat-4'
+		]);
+		expect(anomalies).toEqual([...anomalies].sort((a, b) => b.percentOver - a.percentOver));
+	});
+});

--- a/src/lib/server/insights/category-anomalies.ts
+++ b/src/lib/server/insights/category-anomalies.ts
@@ -1,0 +1,74 @@
+import type { CategoryAnomaly, Transaction } from '$lib/types';
+
+// Require at least this many prior months of history before flagging anything, so a
+// category with only 1-2 months on record doesn't produce a noisy "anomaly" on day one.
+const MIN_PRIOR_MONTHS = 3;
+// Skip categories whose trailing average is trivially small (e.g. a $5/mo category jumping
+// to $8 isn't a meaningful anomaly, even though it's a large percentage change).
+const MIN_BASELINE_AMOUNT = 30;
+const ANOMALY_RATIO = 1.25;
+const MAX_ANOMALIES = 5;
+
+export type HistoricalMonthRange = {
+	monthStart: string;
+	monthEnd: string;
+};
+
+export function computeCategoryAnomalies(
+	transactions: Transaction[],
+	historicalMonths: HistoricalMonthRange[]
+): CategoryAnomaly[] {
+	if (historicalMonths.length < MIN_PRIOR_MONTHS + 1) {
+		return [];
+	}
+
+	const currentRange = historicalMonths[historicalMonths.length - 1];
+	const priorRanges = historicalMonths.slice(0, -1);
+
+	const categoryTotals = new Map<string, { name: string; current: number; priorTotal: number }>();
+
+	for (const tx of transactions) {
+		if (!tx.category) continue;
+
+		const datePart = tx.date.substring(0, 10);
+		const inCurrent = datePart >= currentRange.monthStart && datePart <= currentRange.monthEnd;
+		const inPrior = priorRanges.some(
+			(range) => datePart >= range.monthStart && datePart <= range.monthEnd
+		);
+
+		if (!inCurrent && !inPrior) continue;
+
+		const existing = categoryTotals.get(tx.category.id) ?? {
+			name: tx.category.name,
+			current: 0,
+			priorTotal: 0
+		};
+
+		if (inCurrent) {
+			existing.current += tx.amount;
+		} else {
+			existing.priorTotal += tx.amount;
+		}
+
+		categoryTotals.set(tx.category.id, existing);
+	}
+
+	const anomalies: CategoryAnomaly[] = [];
+
+	for (const [categoryId, { name, current, priorTotal }] of categoryTotals) {
+		const trailingAverage = priorTotal / priorRanges.length;
+
+		if (trailingAverage < MIN_BASELINE_AMOUNT) continue;
+		if (current <= trailingAverage * ANOMALY_RATIO) continue;
+
+		anomalies.push({
+			categoryId,
+			categoryName: name,
+			currentAmount: current,
+			trailingAverage,
+			percentOver: Math.round((current / trailingAverage - 1) * 100)
+		});
+	}
+
+	return anomalies.sort((a, b) => b.percentOver - a.percentOver).slice(0, MAX_ANOMALIES);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -171,6 +171,14 @@ export type ExcludedSpendCategory = {
 	amount: number;
 };
 
+export type CategoryAnomaly = {
+	categoryId: string;
+	categoryName: string;
+	currentAmount: number;
+	trailingAverage: number;
+	percentOver: number;
+};
+
 export type MonthlyNetflowData = {
 	month: string;
 	net: number;

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -1,12 +1,17 @@
 import type {
+	CategoryAnomaly,
 	ExcludedSpendCategory,
 	SavingsGoalWithProgress,
 	TimeRangeInOutData,
 	Transaction
 } from '$lib';
+import { dashboardVisibilitySchema, transactionSchema } from '$lib/formSchemas';
+import { requireAuth } from '$lib/server/actions/auth-guard';
+import { requireUser } from '$lib/server/auth-guard-load';
 import { getDb } from '$lib/server/db';
 import {
 	budgetQueries,
+	dashboardPreferenceQueries,
 	incomeQueries,
 	recurringQueries,
 	savingsGoalQueries,
@@ -14,6 +19,8 @@ import {
 	transactionQueries
 } from '$lib/server/db/queries';
 import { contribution } from '$lib/server/db/schema';
+import { computeCategoryAnomalies } from '$lib/server/insights/category-anomalies';
+import { logger } from '$lib/server/logger';
 import { monthNames } from '$lib/utils';
 import {
 	getCalendarYearMonthsRange,
@@ -23,8 +30,10 @@ import {
 	getYearDateRange
 } from '$lib/utils/dates';
 import { inArray, sum } from 'drizzle-orm';
+import { message, superValidate } from 'sveltekit-superforms';
+import { zod4 } from 'sveltekit-superforms/adapters';
 
-import type { PageServerLoad } from './$types';
+import type { Actions, PageServerLoad } from './$types';
 
 type RecurringItem = { cadence: string; amount: number };
 
@@ -136,6 +145,7 @@ async function loadMonthlyDashboard(url: URL) {
 	}
 
 	const monthlyInOutData: TimeRangeInOutData[] = [];
+	let categoryAnomalies: CategoryAnomaly[] = [];
 
 	if (historicalMonths.length > 0) {
 		const chartStart = historicalMonths[0].monthStart;
@@ -159,6 +169,8 @@ async function loadMonthlyDashboard(url: URL) {
 				out: monthTx.reduce((acc, t) => acc + t.amount, 0) + recurringMonthlyTotal
 			});
 		}
+
+		categoryAnomalies = computeCategoryAnomalies(allChartTx, historicalMonths);
 	}
 
 	const netflowSparkline = monthlyInOutData.map((d) => ({ month: d.month, value: d.in - d.out }));
@@ -180,6 +192,7 @@ async function loadMonthlyDashboard(url: URL) {
 		monthlyInOutData,
 		netflowSparkline,
 		spendingSparkline,
+		categoryAnomalies,
 		goalsWithProgress,
 		totalSavings
 	};
@@ -285,8 +298,46 @@ async function loadYearlyDashboard(url: URL) {
 	};
 }
 
-export const load: PageServerLoad = async ({ url }) => {
+export const load: PageServerLoad = async ({ url, locals }) => {
+	const user = requireUser(locals);
 	const mode = url.searchParams.get('mode') === 'yearly' ? 'yearly' : 'monthly';
-	if (mode === 'monthly') return loadMonthlyDashboard(url);
-	return loadYearlyDashboard(url);
+
+	const [dashboardData, hiddenSections, transactionForm] = await Promise.all([
+		mode === 'monthly' ? loadMonthlyDashboard(url) : loadYearlyDashboard(url),
+		dashboardPreferenceQueries.findHiddenKeysByUserId(user.id),
+		superValidate(zod4(transactionSchema))
+	]);
+
+	const dashboardVisibilityForm = await superValidate(
+		{ hiddenSections },
+		zod4(dashboardVisibilitySchema)
+	);
+
+	return { ...dashboardData, hiddenSections, dashboardVisibilityForm, transactionForm };
 };
+
+export const actions = {
+	updateVisibility: requireAuth(async ({ request }, user) => {
+		const form = await superValidate(request, zod4(dashboardVisibilitySchema));
+
+		if (!form.valid) {
+			return message(
+				form,
+				{ type: 'error', text: 'Please correct the errors in the form.' },
+				{ status: 400 }
+			);
+		}
+
+		try {
+			await dashboardPreferenceQueries.setHiddenKeys(user.id, form.data.hiddenSections);
+			return message(form, { type: 'success', text: 'Dashboard preferences updated.' });
+		} catch (error) {
+			logger.error('Failed to update dashboard section preferences', error);
+			return message(
+				form,
+				{ type: 'error', text: 'Failed to update dashboard preferences. Please try again.' },
+				{ status: 500 }
+			);
+		}
+	})
+} satisfies Actions;

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -8,7 +8,9 @@
 	import CardBeam from '$lib/components/CardBeam.svelte';
 	import CardGridSkeleton from '$lib/components/CardGridSkeleton.svelte';
 	import CashFlowProjectionCard from '$lib/components/CashFlowProjectionCard.svelte';
+	import CategoryAnomalyAlert from '$lib/components/CategoryAnomalyAlert.svelte';
 	import CategoryTransactionSheet from '$lib/components/CategoryTransactionSheet.svelte';
+	import DashboardCustomizePopover from '$lib/components/DashboardCustomizePopover.svelte';
 	import ExcludedSpendList from '$lib/components/ExcludedSpendList.svelte';
 	import GoalsSummaryStrip from '$lib/components/GoalsSummaryStrip.svelte';
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
@@ -20,17 +22,20 @@
 	import RecurringExpensesCard from '$lib/components/RecurringExpensesCard.svelte';
 	import SafeToSpendHeroBand from '$lib/components/SafeToSpendHeroBand.svelte';
 	import SpendingBreakdownChart from '$lib/components/SpendingBreakdownChart.svelte';
+	import TransactionModal from '$lib/components/TransactionModal.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
 	import * as Select from '$lib/components/ui/select/index.js';
 	import * as Tabs from '$lib/components/ui/tabs/index.js';
 	import UpcomingBillsCard from '$lib/components/UpcomingBillsCard.svelte';
 	import { getCategoriesContext } from '$lib/contexts';
+	import { dashboardSectionsForMode } from '$lib/dashboardSections';
 	import { formatCurrency, monthNames, months } from '$lib/utils';
 	import { computeCashFlowProjection } from '$lib/utils/cashFlowProjection';
 	import { getYearProgress } from '$lib/utils/dates';
 	import { usePendingReload } from '$lib/utils/pendingNavigation.svelte';
 	import { ChevronDownIcon } from '@lucide/svelte';
-	import { LandmarkIcon, PiggyBankIcon, WalletIcon } from '@lucide/svelte/icons';
+	import { LandmarkIcon, PiggyBankIcon, PlusIcon, WalletIcon } from '@lucide/svelte/icons';
 	import { SvelteMap } from 'svelte/reactivity';
 
 	import type { PageProps } from './$types';
@@ -79,6 +84,9 @@
 	// Transaction drawer
 	let openTransactionSheet = $state(false);
 	let selectedCategoryId = $state<string | null>(null);
+
+	// Quick action: log a new expense without navigating away
+	let openLogExpenseModal = $state(false);
 
 	const categories = getCategoriesContext();
 	const dashboardPath = resolve('/dashboard');
@@ -302,6 +310,16 @@
 	// KPI sparkline data
 	let netflowSparkline = $derived(data.netflowSparkline || []);
 	let spendingSparkline = $derived(data.spendingSparkline || []);
+	let categoryAnomalies = $derived(data.categoryAnomalies || []);
+
+	// Dashboard section show/hide preferences
+	let visibleSections = $derived(
+		dashboardSectionsForMode(selectedMode === 'yearly' ? 'yearly' : 'monthly')
+	);
+	let hiddenSectionKeys = $derived(new Set(data.hiddenSections || []));
+	function isSectionVisible(key: string): boolean {
+		return !hiddenSectionKeys.has(key);
+	}
 	let netBalanceTrend = $derived(currencyDeltaTrend(netflowSparkline));
 	let spendTrend = $derived(spendPercentTrend(spendingSparkline));
 
@@ -409,6 +427,17 @@
 			<div class="w-full lg:ml-auto lg:w-136">
 				<div class="grid gap-3">
 					<div class="flex justify-end gap-3">
+						<Button size="sm" class="gap-2" onclick={() => (openLogExpenseModal = true)}>
+							<PlusIcon class="size-4" />
+							Log Expense
+						</Button>
+						<DashboardCustomizePopover
+							sections={visibleSections}
+							dashboardVisibilityForm={data.dashboardVisibilityForm}
+						/>
+					</div>
+
+					<div class="flex justify-end gap-3">
 						{#if selectedMode === 'monthly'}
 							<div class="w-44">
 								<Select.Root type="single" value={selectedMonth} onValueChange={onMonthChange}>
@@ -490,107 +519,115 @@
 		/>
 	{:else if selectedMode === 'monthly'}
 		<!-- Safe-to-spend hero band -->
-		<div class="mb-6">
-			<SafeToSpendHeroBand
-				dailyDiscretionary={projection.dailyDiscretionary}
-				{netBalance}
-				daysRemainingInclusive={projection.daysRemainingInclusive}
-			/>
-		</div>
-
-		<!-- KPI Sparkline Row -->
-		<div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
-			<KpiSparklineCard
-				label="Net Balance"
-				value={formatCurrency(netBalance)}
-				subtext="income minus spending"
-				colorScheme={netBalance >= 0 ? 'green' : 'red'}
-				sparklineData={netflowSparkline}
-				trendDirection={netBalanceTrend?.direction}
-				trendLabel={netBalanceTrend?.label}
-				tooltip="Your income minus all spending this month. Positive means you're ahead; negative means you've spent more than you earned. The chart shows the trend over the last 6 months."
-			/>
-			<KpiSparklineCard
-				label="Discretionary Budget Used"
-				icon={WalletIcon}
-				value={`${nonRecurringBudgetPct.toFixed(0)}%`}
-				subtext="of planned budget"
-				colorScheme={nonRecurringBudgetPct > 100
-					? 'red'
-					: nonRecurringBudgetPct > 85
-						? 'amber'
-						: 'green'}
-				sparklineData={spendingSparkline}
-				trendDirection={spendTrend?.direction}
-				trendLabel={spendTrend?.label}
-				tooltip="Your discretionary spending vs. planned budget, excluding recurring expenses. More sensitive than the all-in % — can read higher because the recurring amount isn't cushioning either side."
-			/>
-			<KpiSparklineCard
-				label="Total Budget Used"
-				icon={LandmarkIcon}
-				value={`${budgetPct.toFixed(0)}%`}
-				subtext="of planned budget (incl. recurring)"
-				colorScheme={budgetPct > 100 ? 'red' : budgetPct > 85 ? 'amber' : 'green'}
-				sparklineData={spendingSparkline}
-				trendDirection={spendTrend?.direction}
-				trendLabel={spendTrend?.label}
-				tooltip="Your total spending vs. total planned budget, including recurring expenses. Can read lower than the excl. recurring % when you're over on discretionary spend, since the recurring amount dilutes both sides equally."
-			/>
-			<KpiSparklineCard
-				label="Recurring Burden"
-				value={`${recurringBurdenPct.toFixed(0)}%`}
-				subtext="of income committed"
-				colorScheme={recurringBurdenPct > 50
-					? 'red'
-					: recurringBurdenPct > 35
-						? 'amber'
-						: 'neutral'}
-				tooltip="The percentage of your income already committed to recurring expenses (subscriptions, bills, etc.). High values leave less room for discretionary spending."
-			/>
-			<KpiSparklineCard
-				label="Total Savings"
-				icon={PiggyBankIcon}
-				value={formatCurrency(data.totalSavings || 0)}
-				subtext="across all savings accounts"
-				colorScheme="green"
-				tooltip="The sum of all your savings accounts, same total shown on the Savings page."
-			/>
-		</div>
-
-		<!-- Monthly budget summary + spending breakdown -->
-		<div class="mb-6 flex flex-col gap-4 lg:grid lg:grid-cols-12">
-			<div class="lg:col-span-5">
-				<CardBeam color="rgb(239, 68, 68)" active={nonRecurringBudgetPct > 100}>
-					<MonthlyBudgetSummaryCard
-						actualSpent={data.actualExpensesTotal || 0}
-						plannedBudget={data.plannedExpensesTotal || 0}
-						totalIncome={data.totalIncome || 0}
-						recurringTotal={recurringMonthlyTotal}
-						excludedSpendTotal={excludedExpensesTotal}
-						excludedSpendBreakdown={data.excludedExpensesBreakdown || []}
-					/>
-				</CardBeam>
-			</div>
-			<div class="lg:col-span-7">
-				<SpendingBreakdownChart
-					chartData={spendingBreakdownData}
-					totalSpent={data.actualExpensesTotal || 0}
-					onSliceClick={openCategoryDetails}
+		{#if isSectionVisible('safeToSpendHero')}
+			<div class="mb-6">
+				<SafeToSpendHeroBand
+					dailyDiscretionary={projection.dailyDiscretionary}
+					{netBalance}
+					daysRemainingInclusive={projection.daysRemainingInclusive}
 				/>
 			</div>
-		</div>
+		{/if}
+
+		<!-- KPI Sparkline Row -->
+		{#if isSectionVisible('kpiRow')}
+			<div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+				<KpiSparklineCard
+					label="Net Balance"
+					value={formatCurrency(netBalance)}
+					subtext="income minus spending"
+					colorScheme={netBalance >= 0 ? 'green' : 'red'}
+					sparklineData={netflowSparkline}
+					trendDirection={netBalanceTrend?.direction}
+					trendLabel={netBalanceTrend?.label}
+					tooltip="Your income minus all spending this month. Positive means you're ahead; negative means you've spent more than you earned. The chart shows the trend over the last 6 months."
+				/>
+				<KpiSparklineCard
+					label="Discretionary Budget Used"
+					icon={WalletIcon}
+					value={`${nonRecurringBudgetPct.toFixed(0)}%`}
+					subtext="of planned budget"
+					colorScheme={nonRecurringBudgetPct > 100
+						? 'red'
+						: nonRecurringBudgetPct > 85
+							? 'amber'
+							: 'green'}
+					sparklineData={spendingSparkline}
+					trendDirection={spendTrend?.direction}
+					trendLabel={spendTrend?.label}
+					tooltip="Your discretionary spending vs. planned budget, excluding recurring expenses. More sensitive than the all-in % — can read higher because the recurring amount isn't cushioning either side."
+				/>
+				<KpiSparklineCard
+					label="Total Budget Used"
+					icon={LandmarkIcon}
+					value={`${budgetPct.toFixed(0)}%`}
+					subtext="of planned budget (incl. recurring)"
+					colorScheme={budgetPct > 100 ? 'red' : budgetPct > 85 ? 'amber' : 'green'}
+					sparklineData={spendingSparkline}
+					trendDirection={spendTrend?.direction}
+					trendLabel={spendTrend?.label}
+					tooltip="Your total spending vs. total planned budget, including recurring expenses. Can read lower than the excl. recurring % when you're over on discretionary spend, since the recurring amount dilutes both sides equally."
+				/>
+				<KpiSparklineCard
+					label="Recurring Burden"
+					value={`${recurringBurdenPct.toFixed(0)}%`}
+					subtext="of income committed"
+					colorScheme={recurringBurdenPct > 50
+						? 'red'
+						: recurringBurdenPct > 35
+							? 'amber'
+							: 'neutral'}
+					tooltip="The percentage of your income already committed to recurring expenses (subscriptions, bills, etc.). High values leave less room for discretionary spending."
+				/>
+				<KpiSparklineCard
+					label="Total Savings"
+					icon={PiggyBankIcon}
+					value={formatCurrency(data.totalSavings || 0)}
+					subtext="across all savings accounts"
+					colorScheme="green"
+					tooltip="The sum of all your savings accounts, same total shown on the Savings page."
+				/>
+			</div>
+		{/if}
+
+		<!-- Monthly budget summary + spending breakdown -->
+		{#if isSectionVisible('monthlyOverview')}
+			<div class="mb-6 flex flex-col gap-4 lg:grid lg:grid-cols-12">
+				<div class="lg:col-span-5">
+					<CardBeam color="rgb(239, 68, 68)" active={nonRecurringBudgetPct > 100}>
+						<MonthlyBudgetSummaryCard
+							actualSpent={data.actualExpensesTotal || 0}
+							plannedBudget={data.plannedExpensesTotal || 0}
+							totalIncome={data.totalIncome || 0}
+							recurringTotal={recurringMonthlyTotal}
+							excludedSpendTotal={excludedExpensesTotal}
+							excludedSpendBreakdown={data.excludedExpensesBreakdown || []}
+						/>
+					</CardBeam>
+				</div>
+				<div class="lg:col-span-7">
+					<SpendingBreakdownChart
+						chartData={spendingBreakdownData}
+						totalSpent={data.actualExpensesTotal || 0}
+						onSliceClick={openCategoryDetails}
+					/>
+				</div>
+			</div>
+		{/if}
 
 		<!-- Cash flow projection (monthly only) -->
-		<div class="mb-6">
-			<CashFlowProjectionCard
-				totalIncome={data.totalIncome || 0}
-				actualSpent={data.actualExpensesTotal || 0}
-				{recurringMonthlyTotal}
-				plannedExpensesTotal={data.plannedExpensesTotal || 0}
-				month={Number(selectedMonth)}
-				year={Number(selectedYear)}
-			/>
-		</div>
+		{#if isSectionVisible('cashFlowProjection')}
+			<div class="mb-6">
+				<CashFlowProjectionCard
+					totalIncome={data.totalIncome || 0}
+					actualSpent={data.actualExpensesTotal || 0}
+					{recurringMonthlyTotal}
+					plannedExpensesTotal={data.plannedExpensesTotal || 0}
+					month={Number(selectedMonth)}
+					year={Number(selectedYear)}
+				/>
+			</div>
+		{/if}
 
 		<!-- Budget alert row (only when over budget) -->
 		{#if overBudgetCategories.length > 0}
@@ -599,8 +636,15 @@
 			</div>
 		{/if}
 
+		<!-- Category anomaly insights (unusual spend vs trailing 6-month average) -->
+		{#if categoryAnomalies.length > 0}
+			<div class="mb-6">
+				<CategoryAnomalyAlert anomalies={categoryAnomalies} onViewCategory={openCategoryDetails} />
+			</div>
+		{/if}
+
 		<!-- Top 6 at-risk categories (always visible) -->
-		{#if topRiskCategories.length > 0}
+		{#if isSectionVisible('categoryOverview') && topRiskCategories.length > 0}
 			<div class="mb-6">
 				<div class="mb-3 flex items-center gap-1.5">
 					<h2 class="text-lg font-semibold">Category Overview</h2>
@@ -631,137 +675,153 @@
 		{/if}
 
 		<!-- Savings goals strip -->
-		{#if (data.goalsWithProgress || []).length > 0}
+		{#if isSectionVisible('goalsStrip') && (data.goalsWithProgress || []).length > 0}
 			<div class="mb-6">
 				<GoalsSummaryStrip goals={data.goalsWithProgress || []} />
 			</div>
 		{/if}
 
 		<!-- Upcoming bills -->
-		<div class="mb-6">
-			<UpcomingBillsCard recurring={data.recurringExpenses || []} />
-		</div>
+		{#if isSectionVisible('upcomingBills')}
+			<div class="mb-6">
+				<UpcomingBillsCard recurring={data.recurringExpenses || []} />
+			</div>
+		{/if}
 
 		<!-- Recurring expenses card -->
-		<div class="mb-6">
-			<RecurringExpensesCard
-				recurring={data.recurringExpenses || []}
-				monthlyTotal={recurringMonthlyTotal}
-			/>
-		</div>
+		{#if isSectionVisible('recurringExpenses')}
+			<div class="mb-6">
+				<RecurringExpensesCard
+					recurring={data.recurringExpenses || []}
+					monthlyTotal={recurringMonthlyTotal}
+				/>
+			</div>
+		{/if}
 
 		<!-- All categories (collapsible, closed by default) -->
-		<Collapsible.Root bind:open={categoriesOpen} class="mt-2">
-			<Collapsible.Trigger class="group mb-4 flex cursor-pointer items-center gap-2">
-				<ChevronDownIcon
-					class="text-muted-foreground h-5 w-5 transition-transform duration-200 {categoriesOpen
-						? ''
-						: '-rotate-90'}"
-				/>
-				<h2 class="text-xl font-semibold">All Categories</h2>
-				<span class="text-muted-foreground text-sm">({sortedCategories.length})</span>
-			</Collapsible.Trigger>
-			<Collapsible.Content>
-				<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-					{#each sortedCategories as category (category.id)}
-						{@const categoryOverBudget = isCategoryOverBudget(category.id)}
-						<CardBeam color={getCategoryBeamColor(category.id)} active={categoryOverBudget}>
-							<button
-								type="button"
-								onclick={() => openCategoryDetails(category.id)}
-								class={`w-full cursor-pointer rounded-xl text-left transition-shadow hover:shadow-md ${categoryOverBudget ? 'ring-destructive/40 ring-1' : ''}`}
-							>
-								<BudgetProgressCard
-									title={category.name}
-									planned={getPlannedAmount(category.id)}
-									actual={getActualAmount(category.id)}
-									label1="Spent"
-								/>
-							</button>
-						</CardBeam>
-					{/each}
-				</div>
-			</Collapsible.Content>
-		</Collapsible.Root>
+		{#if isSectionVisible('allCategories')}
+			<Collapsible.Root bind:open={categoriesOpen} class="mt-2">
+				<Collapsible.Trigger class="group mb-4 flex cursor-pointer items-center gap-2">
+					<ChevronDownIcon
+						class="text-muted-foreground h-5 w-5 transition-transform duration-200 {categoriesOpen
+							? ''
+							: '-rotate-90'}"
+					/>
+					<h2 class="text-xl font-semibold">All Categories</h2>
+					<span class="text-muted-foreground text-sm">({sortedCategories.length})</span>
+				</Collapsible.Trigger>
+				<Collapsible.Content>
+					<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						{#each sortedCategories as category (category.id)}
+							{@const categoryOverBudget = isCategoryOverBudget(category.id)}
+							<CardBeam color={getCategoryBeamColor(category.id)} active={categoryOverBudget}>
+								<button
+									type="button"
+									onclick={() => openCategoryDetails(category.id)}
+									class={`w-full cursor-pointer rounded-xl text-left transition-shadow hover:shadow-md ${categoryOverBudget ? 'ring-destructive/40 ring-1' : ''}`}
+								>
+									<BudgetProgressCard
+										title={category.name}
+										planned={getPlannedAmount(category.id)}
+										actual={getActualAmount(category.id)}
+										label1="Spent"
+									/>
+								</button>
+							</CardBeam>
+						{/each}
+					</div>
+				</Collapsible.Content>
+			</Collapsible.Root>
+		{/if}
 	{:else}
 		<!-- Yearly YTD KPI row -->
-		<div class="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-			<div class="bg-card rounded-xl border p-4 shadow-xs">
-				<p class="text-muted-foreground text-sm">YTD Income</p>
-				<p class="mt-1 text-2xl font-bold tabular-nums">{formatCurrency(data.totalIncome || 0)}</p>
-			</div>
-			<div class="bg-card rounded-xl border p-4 shadow-xs">
-				<p class="text-muted-foreground text-sm">YTD Spent</p>
-				<p class="mt-1 text-2xl font-bold tabular-nums">
-					{formatCurrency(data.actualExpensesTotal || 0)}
-				</p>
-			</div>
-			<div class="bg-card rounded-xl border p-4 shadow-xs">
-				<p class="text-muted-foreground text-sm">YTD Net</p>
-				<p
-					class={`mt-1 text-2xl font-bold tabular-nums ${ytdNet >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'}`}
-				>
-					{ytdNet >= 0 ? '+' : ''}{formatCurrency(ytdNet)}
-				</p>
-			</div>
-			<div class="bg-card rounded-xl border p-4 shadow-xs">
-				<p class="text-muted-foreground text-sm">Total Savings</p>
-				<p class="mt-1 text-2xl font-bold text-green-600 tabular-nums dark:text-green-400">
-					{formatCurrency(data.totalSavings || 0)}
-				</p>
-				<p class="text-muted-foreground mt-1 text-xs">Across all savings accounts</p>
-			</div>
-			{#if excludedExpensesTotal > 0}
-				<div class="bg-card rounded-xl border p-4 text-sm shadow-xs">
-					<p class="text-muted-foreground mb-1 text-sm">YTD Excluded Spend</p>
-					<ExcludedSpendList
-						total={excludedExpensesTotal}
-						breakdown={data.excludedExpensesBreakdown || []}
-					/>
+		{#if isSectionVisible('ytdStats')}
+			<div class="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+				<div class="bg-card rounded-xl border p-4 shadow-xs">
+					<p class="text-muted-foreground text-sm">YTD Income</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatCurrency(data.totalIncome || 0)}
+					</p>
 				</div>
-			{/if}
-		</div>
+				<div class="bg-card rounded-xl border p-4 shadow-xs">
+					<p class="text-muted-foreground text-sm">YTD Spent</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatCurrency(data.actualExpensesTotal || 0)}
+					</p>
+				</div>
+				<div class="bg-card rounded-xl border p-4 shadow-xs">
+					<p class="text-muted-foreground text-sm">YTD Net</p>
+					<p
+						class={`mt-1 text-2xl font-bold tabular-nums ${ytdNet >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'}`}
+					>
+						{ytdNet >= 0 ? '+' : ''}{formatCurrency(ytdNet)}
+					</p>
+				</div>
+				<div class="bg-card rounded-xl border p-4 shadow-xs">
+					<p class="text-muted-foreground text-sm">Total Savings</p>
+					<p class="mt-1 text-2xl font-bold text-green-600 tabular-nums dark:text-green-400">
+						{formatCurrency(data.totalSavings || 0)}
+					</p>
+					<p class="text-muted-foreground mt-1 text-xs">Across all savings accounts</p>
+				</div>
+				{#if excludedExpensesTotal > 0}
+					<div class="bg-card rounded-xl border p-4 text-sm shadow-xs">
+						<p class="text-muted-foreground mb-1 text-sm">YTD Excluded Spend</p>
+						<ExcludedSpendList
+							total={excludedExpensesTotal}
+							breakdown={data.excludedExpensesBreakdown || []}
+						/>
+					</div>
+				{/if}
+			</div>
+		{/if}
 
 		<!-- Net Savings table (yearly) -->
-		<div class="mb-6">
-			<MonthlyNetSavingsCard chartData={data.timeRangeData || []} />
-		</div>
+		{#if isSectionVisible('netSavingsTable')}
+			<div class="mb-6">
+				<MonthlyNetSavingsCard chartData={data.timeRangeData || []} />
+			</div>
+		{/if}
 
 		<!-- Monthly netflow trend (yearly) -->
-		<div class="mb-6">
-			<MonthlyNetflowChart chartData={monthlyNetflowData} />
-		</div>
+		{#if isSectionVisible('trendCharts')}
+			<div class="mb-6">
+				<MonthlyNetflowChart chartData={monthlyNetflowData} />
+			</div>
+		{/if}
 
 		<!-- Savings goals strip (yearly) -->
-		{#if (data.goalsWithProgress || []).length > 0}
+		{#if isSectionVisible('goalsStrip') && (data.goalsWithProgress || []).length > 0}
 			<div class="mb-6">
 				<GoalsSummaryStrip goals={data.goalsWithProgress || []} />
 			</div>
 		{/if}
 
 		<!-- All category charts (yearly) -->
-		<Collapsible.Root bind:open={spentByCategoryOpen} class="mt-2">
-			<Collapsible.Trigger class="group mb-4 flex cursor-pointer items-center gap-2">
-				<ChevronDownIcon
-					class="text-muted-foreground h-5 w-5 transition-transform duration-200 {spentByCategoryOpen
-						? ''
-						: '-rotate-90'}"
-				/>
-				<h2 class="text-xl font-semibold">Spent by Category</h2>
-			</Collapsible.Trigger>
-			<Collapsible.Content>
-				<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-					{#each sortedCategories as category (category.id)}
-						{@const categoryMonthlyData = getCategoryMonthlyData(category.id)}
-						<MonthlyCategoryChart
-							chartTitle={category?.name}
-							chartData={categoryMonthlyData}
-							chartDescription={categoryChartDescription}
-						/>
-					{/each}
-				</div>
-			</Collapsible.Content>
-		</Collapsible.Root>
+		{#if isSectionVisible('spentByCategory')}
+			<Collapsible.Root bind:open={spentByCategoryOpen} class="mt-2">
+				<Collapsible.Trigger class="group mb-4 flex cursor-pointer items-center gap-2">
+					<ChevronDownIcon
+						class="text-muted-foreground h-5 w-5 transition-transform duration-200 {spentByCategoryOpen
+							? ''
+							: '-rotate-90'}"
+					/>
+					<h2 class="text-xl font-semibold">Spent by Category</h2>
+				</Collapsible.Trigger>
+				<Collapsible.Content>
+					<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						{#each sortedCategories as category (category.id)}
+							{@const categoryMonthlyData = getCategoryMonthlyData(category.id)}
+							<MonthlyCategoryChart
+								chartTitle={category?.name}
+								chartData={categoryMonthlyData}
+								chartDescription={categoryChartDescription}
+							/>
+						{/each}
+					</div>
+				</Collapsible.Content>
+			</Collapsible.Root>
+		{/if}
 	{/if}
 </div>
 
@@ -774,3 +834,9 @@
 		year={parseInt(selectedYear)}
 	/>
 {/if}
+
+<TransactionModal
+	bind:open={openLogExpenseModal}
+	categories={categories()}
+	transactionForm={data.transactionForm}
+/>


### PR DESCRIPTION
## Summary

Closes the remaining "Bigger bets" from #313, plus the quick-actions item folded in during implementation:

- **Category anomaly insights (#13)**: new `computeCategoryAnomalies` flags a category when its current-month spend is >25% above its trailing 6-month average (min $30 baseline, requires ≥3 prior months of history). Surfaced via a new `CategoryAnomalyAlert` card below the existing budget alert row.
- **Dashboard section visibility (#15)**: a "Customize" popover lets each user show/hide dashboard sections independently. Backed by a new `dashboard_section_preference` table (opt-out model — a row means the section is hidden; no row = visible, so new sections default to visible with no backfill).
- **Quick actions (#14)**: "Log Expense" opens the existing `TransactionModal` right on the dashboard (reuses `/transactions?/create`, no new server logic). "Mark Paid" on `UpcomingBillsCard` reuses the existing `/recurring?/togglePaid` action.
- **Fix**: `SidebarInset` (shared shadcn UI primitive) was missing `min-w-0`, letting wide dashboard content (the Savings Goals horizontal-scroll strip) force the whole page wider than the viewport at several breakpoints (~768px, ~1024–1150px). Confirmed pre-existing via `git stash` against the original code, not introduced by this branch — but found and fixed while verifying the dashboard fits across breakpoints.

## Test plan

- [x] `npm run check` / `npm run lint` / `npm test` all pass (339/339 tests, including 6 new tests for `computeCategoryAnomalies`)
- [x] Manually verified in Chrome: Customize popover toggles + persists section visibility across reload; Log Expense creates a transaction and updates KPIs live; Mark Paid removes a bill from Upcoming Bills and flips it to Paid in Recurring Expenses
- [x] Swept viewport widths 500–1920px in both Monthly and Yearly mode confirming no horizontal overflow after the `SidebarInset` fix
- [ ] Reviewer: eyeball the anomaly callout with a category that's actually >25% over its 6-month average (none of the seeded test data triggers it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)