### PR TITLE
Fix misleading "days left" text for past/future months on Dashboard

### DIFF
--- a/src/lib/components/CashFlowProjectionCard.svelte
+++ b/src/lib/components/CashFlowProjectionCard.svelte
@@ -5,6 +5,7 @@
 	import * as Separator from '$lib/components/ui/separator/index.js';
 	import { formatCurrency } from '$lib/utils';
 	import { computeCashFlowProjection } from '$lib/utils/cashFlowProjection';
+	import { getMonthProgress } from '$lib/utils/dates';
 	import { CalendarIcon } from '@lucide/svelte/icons';
 
 	interface Props {
@@ -44,6 +45,7 @@
 	let discretionaryRemaining = $derived(projection.discretionaryRemaining);
 	let dailyDiscretionary = $derived(projection.dailyDiscretionary);
 	let dailyBudgetRemaining = $derived(projection.dailyBudgetRemaining);
+	let monthStatus = $derived(getMonthProgress(month, year).status);
 
 	let projectionColor = $derived(
 		projectedEnd > totalIncome
@@ -71,9 +73,15 @@
 				maxWidth="max-w-72"
 				text="Shows where your money stands this month. The left side breaks down income, what you've spent on transactions, and recurring commitments to calculate your discretionary budget remaining. The right side projects your total spend by month-end based on your daily burn rate, and shows how much you can safely spend per day."
 			/>
-			<span class="text-muted-foreground ml-auto text-xs"
-				>{daysRemainingInclusive} day{daysRemainingInclusive === 1 ? '' : 's'} remaining</span
-			>
+			<span class="text-muted-foreground ml-auto text-xs">
+				{#if monthStatus === 'past'}
+					Month complete
+				{:else if monthStatus === 'future'}
+					Not started yet
+				{:else}
+					{daysRemainingInclusive} day{daysRemainingInclusive === 1 ? '' : 's'} remaining
+				{/if}
+			</span>
 		</div>
 	</Card.Header>
 	<Card.Content class="pt-0">

--- a/src/lib/components/SafeToSpendHeroBand.svelte
+++ b/src/lib/components/SafeToSpendHeroBand.svelte
@@ -2,19 +2,23 @@
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import { formatCurrency } from '$lib/utils';
+	import { getMonthProgress } from '$lib/utils/dates';
 	import { WalletIcon } from '@lucide/svelte/icons';
 
 	interface Props {
 		dailyDiscretionary: number;
 		netBalance: number;
 		daysRemainingInclusive: number;
+		month: number;
+		year: number;
 	}
 
-	let { dailyDiscretionary, netBalance, daysRemainingInclusive }: Props = $props();
+	let { dailyDiscretionary, netBalance, daysRemainingInclusive, month, year }: Props = $props();
 
 	let netBalanceColor = $derived(
 		netBalance >= 0 ? 'text-green-600 dark:text-green-400' : 'text-destructive'
 	);
+	let monthStatus = $derived(getMonthProgress(month, year).status);
 </script>
 
 <Card.Root class="from-primary/5 to-card dark:bg-card bg-linear-to-t shadow-xs">
@@ -45,7 +49,13 @@
 				{netBalance < 0 ? '-' : ''}{formatCurrency(Math.abs(netBalance))}
 			</p>
 			<p class="text-muted-foreground text-xs">
-				{daysRemainingInclusive} day{daysRemainingInclusive === 1 ? '' : 's'} left
+				{#if monthStatus === 'past'}
+					Month complete
+				{:else if monthStatus === 'future'}
+					Not started yet
+				{:else}
+					{daysRemainingInclusive} day{daysRemainingInclusive === 1 ? '' : 's'} left
+				{/if}
 			</p>
 		</div>
 	</Card.Content>

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -32,7 +32,7 @@
 	import { dashboardSectionsForMode } from '$lib/dashboardSections';
 	import { formatCurrency, monthNames, months } from '$lib/utils';
 	import { computeCashFlowProjection } from '$lib/utils/cashFlowProjection';
-	import { getYearProgress } from '$lib/utils/dates';
+	import { getMonthProgress, getYearProgress } from '$lib/utils/dates';
 	import { usePendingReload } from '$lib/utils/pendingNavigation.svelte';
 	import { ChevronDownIcon } from '@lucide/svelte';
 	import { LandmarkIcon, PiggyBankIcon, PlusIcon, WalletIcon } from '@lucide/svelte/icons';
@@ -299,10 +299,16 @@
 	let headerGreeting = $derived(firstName ? `Hi, ${firstName}` : 'Dashboard');
 	let headerSubtitle = $derived.by(() => {
 		if (selectedMode === 'monthly') {
+			const monthName = monthNames[Number(selectedMonth) - 1];
+			const monthProgress = getMonthProgress(Number(selectedMonth), Number(selectedYear));
+			if (monthProgress.status === 'past') return `${monthName} is complete`;
+			if (monthProgress.status === 'future') return `${monthName} hasn't started yet`;
 			const days = projection.daysRemainingInclusive;
-			return `${days} day${days === 1 ? '' : 's'} left in ${monthNames[Number(selectedMonth) - 1]}`;
+			return `${days} day${days === 1 ? '' : 's'} left in ${monthName}`;
 		}
 		const yearProgress = getYearProgress(Number(selectedYear));
+		if (yearProgress.status === 'past') return `${selectedYear} is complete`;
+		if (yearProgress.status === 'future') return `${selectedYear} hasn't started yet`;
 		const monthsLeft = Math.max(yearProgress.totalUnits - yearProgress.elapsedUnits, 0);
 		return `${monthsLeft} month${monthsLeft === 1 ? '' : 's'} left in ${selectedYear}`;
 	});
@@ -525,6 +531,8 @@
 					dailyDiscretionary={projection.dailyDiscretionary}
 					{netBalance}
 					daysRemainingInclusive={projection.daysRemainingInclusive}
+					month={Number(selectedMonth)}
+					year={Number(selectedYear)}
 				/>
 			</div>
 		{/if}


### PR DESCRIPTION
## Summary
- The Dashboard header, Safe-to-Spend hero band, and Cash Flow Projection card all said something like "1 day left in June" when viewing a past or future month, since the underlying `computeCashFlowProjection()` clamps day counts to 1 outside the current month.
- Now all three use the existing (previously unused) `getMonthProgress`/`getYearProgress` status helpers to show `"<Month> is complete"` for past months and `"<Month> hasn't started yet"` for future months. Current-month behavior is unchanged.
- Applied the same past/future wording to the yearly-mode header subtitle for consistency (it previously said "0 months left" for a past year).

Fixes #329

## Test plan
- [x] `npm run check` — 0 type errors
- [x] `npm run test` — 339 tests passed
- [x] Manually verified in browser: past month (June 2026) → "June is complete"; future month (October 2026) → "October hasn't started yet"; current month (August 2026, no query params) → unchanged "N days left in August"; past year (2025) → "2025 is complete"

🤖 Generated with [Claude Code](https://claude.com/claude-code)