### PR TITLE
Hide confusing dashboard figures for past/future months

### DIFF
--- a/src/lib/components/CashFlowProjectionCard.svelte
+++ b/src/lib/components/CashFlowProjectionCard.svelte
@@ -122,59 +122,65 @@
 
 			<!-- Right: projection -->
 			<div class="flex flex-col justify-center gap-4">
-				<div>
-					<div class="mb-1.5 flex items-center justify-between">
-						<div class="flex items-center gap-1">
-							<span class="text-muted-foreground text-xs">Projected month-end spend</span>
-							<InfoTooltip
-								size="sm"
-								text="Based on your daily burn rate so far this month ({formatCurrency(
-									dailyBurnRate
-								)}/day). Current spend ÷ days elapsed × days remaining, added to current spend."
-							/>
+				{#if monthStatus === 'current'}
+					<div>
+						<div class="mb-1.5 flex items-center justify-between">
+							<div class="flex items-center gap-1">
+								<span class="text-muted-foreground text-xs">Projected month-end spend</span>
+								<InfoTooltip
+									size="sm"
+									text="Based on your daily burn rate so far this month ({formatCurrency(
+										dailyBurnRate
+									)}/day). Current spend ÷ days elapsed × days remaining, added to current spend."
+								/>
+							</div>
+							<span class="text-sm font-bold tabular-nums {projectionColor}">
+								{formatCurrency(projectedEnd)}
+							</span>
 						</div>
-						<span class="text-sm font-bold tabular-nums {projectionColor}">
-							{formatCurrency(projectedEnd)}
-						</span>
+						<Progress value={projectionPercent} class="h-2.5 {progressClass}" />
+						<p class="text-muted-foreground mt-1 text-right text-xs">
+							of {formatCurrency(totalIncome)}
+						</p>
 					</div>
-					<Progress value={projectionPercent} class="h-2.5 {progressClass}" />
-					<p class="text-muted-foreground mt-1 text-right text-xs">
-						of {formatCurrency(totalIncome)}
-					</p>
-				</div>
 
-				<div class="grid grid-cols-2 gap-2">
-					<div class="bg-muted/50 rounded-lg px-3 py-3">
-						<div class="flex items-center gap-1">
-							<p class="text-muted-foreground text-xs">Daily budget</p>
-							<InfoTooltip
-								size="sm"
-								text="Your planned budget remaining (planned total − spent so far) divided by days left in the month. This is what your budget plan says you can spend per day."
-							/>
+					<div class="grid grid-cols-2 gap-2">
+						<div class="bg-muted/50 rounded-lg px-3 py-3">
+							<div class="flex items-center gap-1">
+								<p class="text-muted-foreground text-xs">Daily budget</p>
+								<InfoTooltip
+									size="sm"
+									text="Your planned budget remaining (planned total − spent so far) divided by days left in the month. This is what your budget plan says you can spend per day."
+								/>
+							</div>
+							<p
+								class="mt-0.5 text-lg font-bold tabular-nums {dailyBudgetRemaining <= 0
+									? 'text-destructive'
+									: 'text-foreground'}"
+							>
+								{formatCurrency(dailyBudgetRemaining)}
+								<span class="text-muted-foreground text-xs font-normal">/day</span>
+							</p>
 						</div>
-						<p
-							class="mt-0.5 text-lg font-bold tabular-nums {dailyBudgetRemaining <= 0
-								? 'text-destructive'
-								: 'text-foreground'}"
-						>
-							{formatCurrency(dailyBudgetRemaining)}
-							<span class="text-muted-foreground text-xs font-normal">/day</span>
-						</p>
-					</div>
-					<div class="bg-muted/50 rounded-lg px-3 py-3">
-						<div class="flex items-center gap-1">
-							<p class="text-muted-foreground text-xs">Daily spend</p>
-							<InfoTooltip
-								size="sm"
-								text="Discretionary left (income − spent − recurring) divided by days remaining. This is what your actual cash position allows you to spend per day."
-							/>
+						<div class="bg-muted/50 rounded-lg px-3 py-3">
+							<div class="flex items-center gap-1">
+								<p class="text-muted-foreground text-xs">Daily spend</p>
+								<InfoTooltip
+									size="sm"
+									text="Discretionary left (income − spent − recurring) divided by days remaining. This is what your actual cash position allows you to spend per day."
+								/>
+							</div>
+							<p class="mt-0.5 text-lg font-bold tabular-nums {projectionColor}">
+								{formatCurrency(dailyDiscretionary)}
+								<span class="text-muted-foreground text-xs font-normal">/day</span>
+							</p>
 						</div>
-						<p class="mt-0.5 text-lg font-bold tabular-nums {projectionColor}">
-							{formatCurrency(dailyDiscretionary)}
-							<span class="text-muted-foreground text-xs font-normal">/day</span>
-						</p>
 					</div>
-				</div>
+				{:else}
+					<p class="text-muted-foreground py-8 text-center text-sm">
+						{monthStatus === 'past' ? 'Month complete' : 'Not started yet'}
+					</p>
+				{/if}
 			</div>
 		</div>
 	</Card.Content>

--- a/src/lib/components/RecurringExpensesCard.svelte
+++ b/src/lib/components/RecurringExpensesCard.svelte
@@ -10,9 +10,10 @@
 	interface Props {
 		recurring: Recurring[];
 		monthlyTotal: number;
+		isCurrentMonth: boolean;
 	}
 
-	let { recurring, monthlyTotal }: Props = $props();
+	let { recurring, monthlyTotal, isCurrentMonth }: Props = $props();
 
 	let open = $state(true);
 
@@ -59,13 +60,15 @@
 									</div>
 								</div>
 								<div class="flex items-center gap-2">
-									{#if item.paid}
-										<Badge class="bg-green-500 text-xs text-white hover:bg-green-500">Paid</Badge>
-									{:else}
-										<Badge
-											class="bg-muted-foreground/30 hover:bg-muted-foreground/30 text-xs text-white"
-											>Not Yet Paid</Badge
-										>
+									{#if isCurrentMonth}
+										{#if item.paid}
+											<Badge class="bg-green-500 text-xs text-white hover:bg-green-500">Paid</Badge>
+										{:else}
+											<Badge
+												class="bg-muted-foreground/30 hover:bg-muted-foreground/30 text-xs text-white"
+												>Not Yet Paid</Badge
+											>
+										{/if}
 									{/if}
 									<Badge variant="outline" class="text-xs">
 										{item.cadence}

--- a/src/lib/components/SafeToSpendHeroBand.svelte
+++ b/src/lib/components/SafeToSpendHeroBand.svelte
@@ -37,10 +37,16 @@
 						text="Discretionary left (income − spent − recurring) divided by days remaining in the month. What your actual cash position allows you to spend per day."
 					/>
 				</div>
-				<p class="text-3xl font-bold tabular-nums">
-					{formatCurrency(dailyDiscretionary)}
-					<span class="text-muted-foreground text-sm font-normal">/day</span>
-				</p>
+				{#if monthStatus === 'current'}
+					<p class="text-3xl font-bold tabular-nums">
+						{formatCurrency(dailyDiscretionary)}
+						<span class="text-muted-foreground text-sm font-normal">/day</span>
+					</p>
+				{:else}
+					<p class="text-muted-foreground text-lg font-medium">
+						{monthStatus === 'past' ? 'Month complete' : 'Not started yet'}
+					</p>
+				{/if}
 			</div>
 		</div>
 		<div class="text-left sm:text-right">

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -294,15 +294,19 @@
 		})
 	);
 
+	// Shared "is the selected month the real current month" status — gates widgets
+	// that only make sense for the month actually in progress (safe-to-spend,
+	// cash flow projection daily figures, upcoming bills, recurring paid status).
+	let monthStatus = $derived(getMonthProgress(Number(selectedMonth), Number(selectedYear)).status);
+
 	// Personalized header greeting + relative-time subtitle
 	let firstName = $derived(data.user?.name?.split(' ')[0] || '');
 	let headerGreeting = $derived(firstName ? `Hi, ${firstName}` : 'Dashboard');
 	let headerSubtitle = $derived.by(() => {
 		if (selectedMode === 'monthly') {
 			const monthName = monthNames[Number(selectedMonth) - 1];
-			const monthProgress = getMonthProgress(Number(selectedMonth), Number(selectedYear));
-			if (monthProgress.status === 'past') return `${monthName} is complete`;
-			if (monthProgress.status === 'future') return `${monthName} hasn't started yet`;
+			if (monthStatus === 'past') return `${monthName} is complete`;
+			if (monthStatus === 'future') return `${monthName} hasn't started yet`;
 			const days = projection.daysRemainingInclusive;
 			return `${days} day${days === 1 ? '' : 's'} left in ${monthName}`;
 		}
@@ -689,8 +693,8 @@
 			</div>
 		{/if}
 
-		<!-- Upcoming bills -->
-		{#if isSectionVisible('upcomingBills')}
+		<!-- Upcoming bills (only meaningful for the current month) -->
+		{#if isSectionVisible('upcomingBills') && monthStatus === 'current'}
 			<div class="mb-6">
 				<UpcomingBillsCard recurring={data.recurringExpenses || []} />
 			</div>
@@ -702,6 +706,7 @@
 				<RecurringExpensesCard
 					recurring={data.recurringExpenses || []}
 					monthlyTotal={recurringMonthlyTotal}
+					isCurrentMonth={monthStatus === 'current'}
 				/>
 			</div>
 		{/if}


### PR DESCRIPTION
## Summary
- Safe to Spend Today's `$/day` figure, Cash Flow Projection's Daily budget/Daily spend tiles and projected month-end bar, Upcoming Bills, and Recurring Expenses' Paid/Not Paid badge all assumed the selected month was the real current month.
- All four are now gated on the existing `getMonthProgress(month, year).status` (already used for subtitle text in two of these cards) so they only show today-relative figures when viewing the actual current month:
  - **Safe to Spend Today**: shows "Month complete" / "Not started yet" in place of the `$/day` figure for past/future months.
  - **Cash Flow Projection**: hides the projected month-end bar + Daily budget/Daily spend tiles for past/future months (left-hand income/spend/recurring breakdown stays visible for any month).
  - **Upcoming Bills**: hidden entirely outside the current month — it's inherently relative to real "today," not the selected month.
  - **Recurring Expenses**: card stays visible for any month, but the Paid/Not Paid badge (which resets globally on the 1st) is only shown for the current month.

Fixes #331

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run test` — 339 tests passed
- [x] `npm run lint` (pre-existing, unrelated "dev deps in production" dead-code warning; not from this change)
- [x] Manual verification in browser (month picker across past/current/future months) — Chrome automation wasn't available in this session; recommend a quick manual pass before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)