### PR TITLE
Factor budgeted amount into category anomaly detection

### DIFF
--- a/src/lib/server/insights/category-anomalies.test.ts
+++ b/src/lib/server/insights/category-anomalies.test.ts
@@ -1,4 +1,4 @@
-import type { Transaction, User } from '$lib/types';
+import type { Budget, Transaction, User } from '$lib/types';
 import { describe, expect, it } from 'vitest';
 
 import { computeCategoryAnomalies, type HistoricalMonthRange } from './category-anomalies';
@@ -51,6 +51,17 @@ function buildPriorMonthsSpend(
 	return priorMonthStarts.map((monthStart) =>
 		buildTx(categoryId, categoryName, amount, monthStart)
 	);
+}
+
+function buildBudget(categoryId: string, categoryName: string, amount: number): Budget {
+	return {
+		id: `budget-${categoryId}`,
+		amount,
+		month: '6',
+		year: '2026',
+		category: { id: categoryId, name: categoryName, description: '', createdAt: '', updatedAt: '' },
+		user: fixtureUser
+	};
 }
 
 describe('computeCategoryAnomalies', () => {
@@ -136,5 +147,54 @@ describe('computeCategoryAnomalies', () => {
 			'cat-4'
 		]);
 		expect(anomalies).toEqual([...anomalies].sort((a, b) => b.percentOver - a.percentOver));
+	});
+
+	it('does not flag a category spending at or under its budget for the current month', () => {
+		const transactions = [
+			...buildPriorMonthsSpend('groceries', 'Groceries', 100),
+			buildTx('groceries', 'Groceries', 140, '2026-06-15')
+		];
+		const budgets = [buildBudget('groceries', 'Groceries', 140)];
+
+		expect(computeCategoryAnomalies(transactions, sixMonthRange, budgets)).toEqual([]);
+	});
+
+	it('still flags a category that spends over both its trailing average and its budget', () => {
+		const transactions = [
+			...buildPriorMonthsSpend('groceries', 'Groceries', 100),
+			buildTx('groceries', 'Groceries', 140, '2026-06-15')
+		];
+		const budgets = [buildBudget('groceries', 'Groceries', 120)];
+
+		const anomalies = computeCategoryAnomalies(transactions, sixMonthRange, budgets);
+
+		expect(anomalies).toEqual([
+			{
+				categoryId: 'groceries',
+				categoryName: 'Groceries',
+				currentAmount: 140,
+				trailingAverage: 100,
+				percentOver: 40
+			}
+		]);
+	});
+
+	it('falls back to average-only detection when no budget is set for the category', () => {
+		const transactions = [
+			...buildPriorMonthsSpend('groceries', 'Groceries', 100),
+			buildTx('groceries', 'Groceries', 140, '2026-06-15')
+		];
+
+		const anomalies = computeCategoryAnomalies(transactions, sixMonthRange, []);
+
+		expect(anomalies).toEqual([
+			{
+				categoryId: 'groceries',
+				categoryName: 'Groceries',
+				currentAmount: 140,
+				trailingAverage: 100,
+				percentOver: 40
+			}
+		]);
 	});
 });

--- a/src/lib/server/insights/category-anomalies.ts
+++ b/src/lib/server/insights/category-anomalies.ts
@@ -1,4 +1,4 @@
-import type { CategoryAnomaly, Transaction } from '$lib/types';
+import type { Budget, CategoryAnomaly, Transaction } from '$lib/types';
 
 // Require at least this many prior months of history before flagging anything, so a
 // category with only 1-2 months on record doesn't produce a noisy "anomaly" on day one.
@@ -16,11 +16,18 @@ export type HistoricalMonthRange = {
 
 export function computeCategoryAnomalies(
 	transactions: Transaction[],
-	historicalMonths: HistoricalMonthRange[]
+	historicalMonths: HistoricalMonthRange[],
+	currentBudgets: Budget[] = []
 ): CategoryAnomaly[] {
 	if (historicalMonths.length < MIN_PRIOR_MONTHS + 1) {
 		return [];
 	}
+
+	const budgetByCategory = new Map(
+		currentBudgets
+			.filter((b): b is Budget & { category: NonNullable<Budget['category']> } => !!b.category)
+			.map((b) => [b.category.id, b.amount])
+	);
 
 	const currentRange = historicalMonths[historicalMonths.length - 1];
 	const priorRanges = historicalMonths.slice(0, -1);
@@ -60,6 +67,11 @@ export function computeCategoryAnomalies(
 
 		if (trailingAverage < MIN_BASELINE_AMOUNT) continue;
 		if (current <= trailingAverage * ANOMALY_RATIO) continue;
+
+		// Spending within (or exactly at) a budget the user set for this category isn't a
+		// surprise, even if it's a big jump over the historical average.
+		const budgetedAmount = budgetByCategory.get(categoryId) ?? 0;
+		if (budgetedAmount > 0 && current <= budgetedAmount) continue;
 
 		anomalies.push({
 			categoryId,

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -170,7 +170,7 @@ async function loadMonthlyDashboard(url: URL) {
 			});
 		}
 
-		categoryAnomalies = computeCategoryAnomalies(allChartTx, historicalMonths);
+		categoryAnomalies = computeCategoryAnomalies(allChartTx, historicalMonths, plannedExpenses);
 	}
 
 	const netflowSparkline = monthlyInOutData.map((d) => ({ month: d.month, value: d.in - d.out }));


### PR DESCRIPTION
## Summary
- Category spend that's at or under the current month's budget is no longer flagged as anomalous, even when it's a big jump over the trailing average — an intentional budget increase shouldn't look like a surprise.
- Overspending still counts as anomalous only when it exceeds both the trailing-average threshold and the category's budget for the month.
- No budget set for a category falls back to the prior average-only behavior.

Fixes #333

## Test plan
- [x] Added unit tests in `category-anomalies.test.ts` covering: spend within budget (not flagged), spend over both average and budget (still flagged), no budget set (unchanged behavior)
- [x] `npx vitest run` — 342 tests pass
- [x] `npm run check` — 0 errors
- [x] `npm run lint` — passes (pre-existing unrelated dev-dependency warning)