### PR TITLE
Fix projected month-end spend inflating recurring costs

### DIFF
--- a/src/lib/components/CashFlowProjectionCard.svelte
+++ b/src/lib/components/CashFlowProjectionCard.svelte
@@ -129,9 +129,9 @@
 								<span class="text-muted-foreground text-xs">Projected month-end spend</span>
 								<InfoTooltip
 									size="sm"
-									text="Based on your daily burn rate so far this month ({formatCurrency(
+									text="Based on your non-recurring daily spend rate so far this month ({formatCurrency(
 										dailyBurnRate
-									)}/day). Current spend ÷ days elapsed × days remaining, added to current spend."
+									)}/day). Recurring commitments are counted in full; this rate projects only your remaining discretionary spend."
 								/>
 							</div>
 							<span class="text-sm font-bold tabular-nums {projectionColor}">

--- a/src/lib/utils/cashFlowProjection.test.ts
+++ b/src/lib/utils/cashFlowProjection.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeCashFlowProjection } from './cashFlowProjection';
+
+describe('computeCashFlowProjection', () => {
+	it('does not smear a fixed recurring cost across the daily burn rate (issue #335)', () => {
+		// Aug 5, 2026: 5 days elapsed, 26 days remaining, 31 days in month.
+		// $150 of real (non-recurring) spend so far, $1,800/mo recurring committed.
+		const result = computeCashFlowProjection({
+			totalIncome: 5000,
+			actualSpent: 1950, // 150 non-recurring + 1800 recurring
+			recurringMonthlyTotal: 1800,
+			plannedExpensesTotal: 4000,
+			month: 8,
+			year: 2026,
+			referenceDate: new Date(2026, 7, 5)
+		});
+
+		expect(result.nonRecurringSpent).toBe(150);
+		expect(result.dailyBurnRate).toBeCloseTo(30); // 150 / 5, not 1950 / 5
+		expect(result.projectedEnd).toBeCloseTo(2730); // 1950 + 30 * 26, not the buggy ~12,090
+	});
+
+	it('reduces to simple linear extrapolation of actual spend when there is no recurring cost', () => {
+		const result = computeCashFlowProjection({
+			totalIncome: 5000,
+			actualSpent: 310,
+			recurringMonthlyTotal: 0,
+			plannedExpensesTotal: 4000,
+			month: 8,
+			year: 2026,
+			referenceDate: new Date(2026, 7, 5)
+		});
+
+		expect(result.dailyBurnRate).toBeCloseTo(62); // 310 / 5
+		expect(result.projectedEnd).toBeCloseTo(1922); // 310 + 62 * 26
+	});
+
+	it('projects to exactly the current spend on the last day of the month', () => {
+		const result = computeCashFlowProjection({
+			totalIncome: 5000,
+			actualSpent: 3200,
+			recurringMonthlyTotal: 1800,
+			plannedExpensesTotal: 4000,
+			month: 8,
+			year: 2026,
+			referenceDate: new Date(2026, 7, 31)
+		});
+
+		expect(result.daysRemaining).toBe(0);
+		expect(result.projectedEnd).toBe(3200);
+	});
+
+	it('clamps to month-end when viewing a past or future month', () => {
+		const pastMonth = computeCashFlowProjection({
+			totalIncome: 5000,
+			actualSpent: 2500,
+			recurringMonthlyTotal: 1800,
+			plannedExpensesTotal: 4000,
+			month: 6,
+			year: 2026,
+			referenceDate: new Date(2026, 7, 5) // viewing June from August
+		});
+		expect(pastMonth.daysElapsed).toBe(pastMonth.daysInMonth);
+		expect(pastMonth.daysRemaining).toBe(0);
+		expect(pastMonth.projectedEnd).toBe(2500);
+
+		const futureMonth = computeCashFlowProjection({
+			totalIncome: 5000,
+			actualSpent: 0,
+			recurringMonthlyTotal: 1800,
+			plannedExpensesTotal: 4000,
+			month: 12,
+			year: 2026,
+			referenceDate: new Date(2026, 7, 5) // viewing December from August
+		});
+		expect(futureMonth.daysElapsed).toBe(futureMonth.daysInMonth);
+		expect(futureMonth.daysRemaining).toBe(0);
+		expect(futureMonth.projectedEnd).toBe(0);
+	});
+
+	it('caps projectionPercent at 100 and leaves unrelated fields correct', () => {
+		const result = computeCashFlowProjection({
+			totalIncome: 1000,
+			actualSpent: 2100, // 100 non-recurring + 2000 recurring
+			recurringMonthlyTotal: 2000,
+			plannedExpensesTotal: 2500,
+			month: 8,
+			year: 2026,
+			referenceDate: new Date(2026, 7, 5)
+		});
+
+		// projectedEnd = 2100 + (100/5)*26 = 2620, well over totalIncome of 1000
+		expect(result.projectedEnd).toBeCloseTo(2620);
+		expect(result.projectionPercent).toBe(100);
+
+		// discretionaryRemaining = totalIncome - nonRecurringSpent - recurringMonthlyTotal
+		expect(result.discretionaryRemaining).toBeCloseTo(1000 - 100 - 2000);
+
+		// budgetRemaining = max(0, plannedExpensesTotal - actualSpent) = max(0, 2500 - 2100)
+		expect(result.budgetRemaining).toBeCloseTo(400);
+		// daysRemainingInclusive = 31 - 5 + 1 = 27
+		expect(result.dailyBudgetRemaining).toBeCloseTo(400 / 27);
+	});
+});

--- a/src/lib/utils/cashFlowProjection.ts
+++ b/src/lib/utils/cashFlowProjection.ts
@@ -43,11 +43,11 @@ export function computeCashFlowProjection({
 	const daysRemaining = Math.max(daysInMonth - currentDay, 0);
 	const daysRemainingInclusive = Math.max(daysInMonth - currentDay + 1, 1);
 
-	const dailyBurnRate = actualSpent / daysElapsed;
+	const nonRecurringSpent = Math.max(0, actualSpent - recurringMonthlyTotal);
+	const dailyBurnRate = nonRecurringSpent / daysElapsed;
 	const projectedEnd = actualSpent + dailyBurnRate * daysRemaining;
 	const projectionPercent = totalIncome > 0 ? Math.min((projectedEnd / totalIncome) * 100, 100) : 0;
 
-	const nonRecurringSpent = Math.max(0, actualSpent - recurringMonthlyTotal);
 	const discretionaryRemaining = totalIncome - nonRecurringSpent - recurringMonthlyTotal;
 	const dailyDiscretionary = Math.max(discretionaryRemaining, 0) / daysRemainingInclusive;
 


### PR DESCRIPTION
## Summary
- `computeCashFlowProjection()` computed `dailyBurnRate` from `actualSpent`, which already includes the full month's `recurringMonthlyTotal` (a fixed cost, e.g. rent/subscriptions). That fixed cost then got re-multiplied by `daysRemaining`, causing "Projected month-end spend" to wildly overshoot early in the month (e.g. projecting >2x income when only a small amount of real/non-recurring spend had happened by day 5).
- Fix: base `dailyBurnRate` on `nonRecurringSpent` instead of `actualSpent`, so recurring costs are counted once (in the `actualSpent` starting point) rather than extrapolated as if they repeat daily.
- Updated the info tooltip copy on the Dashboard's Cash Flow Projection card to describe the corrected non-recurring daily rate.
- Added regression tests in `src/lib/utils/cashFlowProjection.test.ts` covering: the original bug scenario (verified against a manually-calculated expected value), no-recurring-cost case, end-of-month case, viewing a past/future month, and `projectionPercent` capping / other untouched fields.

Closes #335

## Test plan
- [x] `npm run test` — all 347 tests pass (5 new)
- [x] `npm run check` (svelte-check) — 0 errors/warnings
- [x] `npm run lint` (oxlint + static checks) — passes (pre-existing unrelated `check:dead-code` dependency warning exists on `main` too, not introduced by this change)
- [x] Manual Dashboard verification in browser — not completed this session (Claude in Chrome extension wasn't connected); recommend a quick manual check of the Cash Flow Projection card on a month with both recurring items and transactions before/after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)