### PR TITLE
Match dashboard copy verb tense to viewed month context

### DIFF
--- a/src/lib/components/CashFlowProjectionCard.svelte
+++ b/src/lib/components/CashFlowProjectionCard.svelte
@@ -71,7 +71,11 @@
 			<Card.Title class="text-base">Cash Flow Projection</Card.Title>
 			<InfoTooltip
 				maxWidth="max-w-72"
-				text="Shows where your money stands this month. The left side breaks down income, what you've spent on transactions, and recurring commitments to calculate your discretionary budget remaining. The right side projects your total spend by month-end based on your daily burn rate, and shows how much you can safely spend per day."
+				text={monthStatus === 'past'
+					? 'Shows where your money stood this month. The left side breaks down income, what you spent on transactions, and recurring commitments to show how much discretionary budget you had left.'
+					: monthStatus === 'future'
+						? 'Shows where your money is projected to stand this month. The left side will break down projected income, spending, and recurring commitments to show your projected discretionary budget.'
+						: "Shows where your money stands this month. The left side breaks down income, what you've spent on transactions, and recurring commitments to calculate your discretionary budget remaining. The right side projects your total spend by month-end based on your daily burn rate, and shows how much you can safely spend per day."}
 			/>
 			<span class="text-muted-foreground ml-auto text-xs">
 				{#if monthStatus === 'past'}
@@ -94,20 +98,38 @@
 				</div>
 				<Separator.Root />
 				<div class="flex justify-between py-2.5">
-					<span class="text-muted-foreground text-sm">Spent so far</span>
+					<span class="text-muted-foreground text-sm"
+						>{monthStatus === 'past'
+							? 'Total spent'
+							: monthStatus === 'future'
+								? 'Spent'
+								: 'Spent so far'}</span
+					>
 					<span class="text-sm font-semibold tabular-nums">{formatCurrency(nonRecurringSpent)}</span
 					>
 				</div>
 				<Separator.Root />
 				<div class="flex justify-between py-2.5">
-					<span class="text-muted-foreground text-sm">Recurring committed</span>
+					<span class="text-muted-foreground text-sm"
+						>{monthStatus === 'past'
+							? 'Recurring paid'
+							: monthStatus === 'future'
+								? 'Recurring due'
+								: 'Recurring committed'}</span
+					>
 					<span class="text-sm font-semibold tabular-nums"
 						>{formatCurrency(recurringMonthlyTotal)}</span
 					>
 				</div>
 				<Separator.Root />
 				<div class="flex justify-between py-2.5">
-					<span class="text-sm font-medium">Discretionary left</span>
+					<span class="text-sm font-medium"
+						>{monthStatus === 'past'
+							? 'Discretionary left over'
+							: monthStatus === 'future'
+								? 'Projected discretionary'
+								: 'Discretionary left'}</span
+					>
 					<span
 						class="text-sm font-bold tabular-nums {discretionaryRemaining >= 0
 							? 'text-green-600 dark:text-green-400'

--- a/src/lib/components/MonthlyBudgetSummaryCard.svelte
+++ b/src/lib/components/MonthlyBudgetSummaryCard.svelte
@@ -3,6 +3,7 @@
 	import { Progress } from '$lib/components/ui/progress';
 	import type { ExcludedSpendCategory } from '$lib/types';
 	import { formatCurrency } from '$lib/utils';
+	import { getMonthProgress } from '$lib/utils/dates';
 
 	import ExcludedSpendList from './ExcludedSpendList.svelte';
 
@@ -14,6 +15,8 @@
 		excludedSpendTotal?: number;
 		excludedSpendBreakdown?: ExcludedSpendCategory[];
 		loading?: boolean;
+		month: number;
+		year: number;
 	}
 
 	let {
@@ -23,8 +26,12 @@
 		recurringTotal = 0,
 		excludedSpendTotal = 0,
 		excludedSpendBreakdown = [],
-		loading = false
+		loading = false,
+		month,
+		year
 	}: Props = $props();
+
+	let monthStatus = $derived(getMonthProgress(month, year).status);
 
 	let nonRecurringSpent = $derived(Math.max(0, actualSpent - recurringTotal));
 	let nonRecurringBudget = $derived(Math.max(0, plannedBudget - recurringTotal));
@@ -65,7 +72,17 @@
 					<p
 						class={`mt-1 text-xs font-medium ${isOverspent ? 'text-destructive' : 'text-green-600 dark:text-green-400'}`}
 					>
-						{isOverspent ? 'Overspent this month' : 'On track this month'}
+						{monthStatus === 'past'
+							? isOverspent
+								? 'Overspent'
+								: 'Stayed on track'
+							: monthStatus === 'future'
+								? isOverspent
+									? 'Projected to overspend'
+									: 'Projected to stay on track'
+								: isOverspent
+									? 'Overspent this month'
+									: 'On track this month'}
 					</p>
 				</div>
 				<div
@@ -123,7 +140,12 @@
 							</p>
 						{:else if nonRecurringBudget > 0}
 							<p class="text-xs font-medium text-green-600 dark:text-green-400">
-								{formatCurrency(nonRecurringBudget - nonRecurringSpent)} left
+								{formatCurrency(nonRecurringBudget - nonRecurringSpent)}
+								{monthStatus === 'past'
+									? 'unused'
+									: monthStatus === 'future'
+										? 'projected leftover'
+										: 'left'}
 							</p>
 						{/if}
 					</div>
@@ -165,7 +187,12 @@
 							</p>
 						{:else if totalIncome > 0}
 							<p class="text-xs font-medium text-green-600 dark:text-green-400">
-								{formatCurrency(totalIncome - actualSpent)} remaining
+								{formatCurrency(totalIncome - actualSpent)}
+								{monthStatus === 'past'
+									? 'saved'
+									: monthStatus === 'future'
+										? 'projected remaining'
+										: 'remaining'}
 							</p>
 						{/if}
 					</div>

--- a/src/lib/components/MonthlyBudgetSummaryCard.test.ts
+++ b/src/lib/components/MonthlyBudgetSummaryCard.test.ts
@@ -3,13 +3,17 @@ import { describe, expect, it } from 'vitest';
 
 import MonthlyBudgetSummaryCard from './MonthlyBudgetSummaryCard.svelte';
 
+const now = new Date();
+const currentMonth = { month: now.getMonth() + 1, year: now.getFullYear() };
+
 describe('MonthlyBudgetSummaryCard', () => {
 	it('renders net balance in the on-track (positive) state', () => {
 		const html = render(MonthlyBudgetSummaryCard, {
 			props: {
 				actualSpent: 800,
 				plannedBudget: 1200,
-				totalIncome: 3000
+				totalIncome: 3000,
+				...currentMonth
 			}
 		}).body;
 
@@ -24,7 +28,8 @@ describe('MonthlyBudgetSummaryCard', () => {
 			props: {
 				actualSpent: 3500,
 				plannedBudget: 4000,
-				totalIncome: 3000
+				totalIncome: 3000,
+				...currentMonth
 			}
 		}).body;
 
@@ -40,7 +45,8 @@ describe('MonthlyBudgetSummaryCard', () => {
 				actualSpent: 500,
 				plannedBudget: 1000,
 				totalIncome: 2000,
-				loading: true
+				loading: true,
+				...currentMonth
 			}
 		}).body;
 
@@ -55,7 +61,8 @@ describe('MonthlyBudgetSummaryCard', () => {
 			props: {
 				actualSpent: 2000,
 				plannedBudget: 2500,
-				totalIncome: 2000
+				totalIncome: 2000,
+				...currentMonth
 			}
 		}).body;
 

--- a/src/lib/components/SafeToSpendHeroBand.svelte
+++ b/src/lib/components/SafeToSpendHeroBand.svelte
@@ -31,7 +31,9 @@
 			</div>
 			<div>
 				<div class="flex items-center gap-1">
-					<p class="text-muted-foreground text-sm">Safe to Spend Today</p>
+					<p class="text-muted-foreground text-sm">
+						{monthStatus === 'current' ? 'Safe to Spend Today' : 'Safe to Spend Per Day'}
+					</p>
 					<InfoTooltip
 						size="sm"
 						text="Discretionary left (income − spent − recurring) divided by days remaining in the month. What your actual cash position allows you to spend per day."

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -552,7 +552,11 @@
 					sparklineData={netflowSparkline}
 					trendDirection={netBalanceTrend?.direction}
 					trendLabel={netBalanceTrend?.label}
-					tooltip="Your income minus all spending this month. Positive means you're ahead; negative means you've spent more than you earned. The chart shows the trend over the last 6 months."
+					tooltip={monthStatus === 'past'
+						? 'Your income minus all spending this month. Positive means you ended up ahead; negative means you spent more than you earned. The chart shows the trend over the last 6 months.'
+						: monthStatus === 'future'
+							? "Your projected income minus projected spending this month. Positive means you're projected to end up ahead; negative means you're projected to spend more than you earn. The chart shows the trend over the last 6 months."
+							: "Your income minus all spending this month. Positive means you're ahead; negative means you've spent more than you earned. The chart shows the trend over the last 6 months."}
 				/>
 				<KpiSparklineCard
 					label="Discretionary Budget Used"
@@ -567,7 +571,11 @@
 					sparklineData={spendingSparkline}
 					trendDirection={spendTrend?.direction}
 					trendLabel={spendTrend?.label}
-					tooltip="Your discretionary spending vs. planned budget, excluding recurring expenses. More sensitive than the all-in % — can read higher because the recurring amount isn't cushioning either side."
+					tooltip={monthStatus === 'past'
+						? "Your discretionary spending vs. planned budget, excluding recurring expenses. More sensitive than the all-in % — could read higher because the recurring amount wasn't cushioning either side."
+						: monthStatus === 'future'
+							? "Your projected discretionary spending vs. planned budget, excluding recurring expenses. More sensitive than the all-in % — can read higher because the recurring amount won't cushion either side."
+							: "Your discretionary spending vs. planned budget, excluding recurring expenses. More sensitive than the all-in % — can read higher because the recurring amount isn't cushioning either side."}
 				/>
 				<KpiSparklineCard
 					label="Total Budget Used"
@@ -578,7 +586,11 @@
 					sparklineData={spendingSparkline}
 					trendDirection={spendTrend?.direction}
 					trendLabel={spendTrend?.label}
-					tooltip="Your total spending vs. total planned budget, including recurring expenses. Can read lower than the excl. recurring % when you're over on discretionary spend, since the recurring amount dilutes both sides equally."
+					tooltip={monthStatus === 'past'
+						? 'Your total spending vs. total planned budget, including recurring expenses. Could read lower than the excl. recurring % when you were over on discretionary spend, since the recurring amount diluted both sides equally.'
+						: monthStatus === 'future'
+							? "Your projected total spending vs. total planned budget, including recurring expenses. Can read lower than the excl. recurring % when you're projected to be over on discretionary spend, since the recurring amount dilutes both sides equally."
+							: "Your total spending vs. total planned budget, including recurring expenses. Can read lower than the excl. recurring % when you're over on discretionary spend, since the recurring amount dilutes both sides equally."}
 				/>
 				<KpiSparklineCard
 					label="Recurring Burden"
@@ -589,7 +601,11 @@
 						: recurringBurdenPct > 35
 							? 'amber'
 							: 'neutral'}
-					tooltip="The percentage of your income already committed to recurring expenses (subscriptions, bills, etc.). High values leave less room for discretionary spending."
+					tooltip={monthStatus === 'past'
+						? 'The percentage of your income that was committed to recurring expenses (subscriptions, bills, etc.). High values left less room for discretionary spending.'
+						: monthStatus === 'future'
+							? 'The percentage of your income projected to be committed to recurring expenses (subscriptions, bills, etc.). High values will leave less room for discretionary spending.'
+							: 'The percentage of your income already committed to recurring expenses (subscriptions, bills, etc.). High values leave less room for discretionary spending.'}
 				/>
 				<KpiSparklineCard
 					label="Total Savings"
@@ -614,6 +630,8 @@
 							recurringTotal={recurringMonthlyTotal}
 							excludedSpendTotal={excludedExpensesTotal}
 							excludedSpendBreakdown={data.excludedExpensesBreakdown || []}
+							month={Number(selectedMonth)}
+							year={Number(selectedYear)}
 						/>
 					</CardBeam>
 				</div>
@@ -661,7 +679,11 @@
 				<div class="mb-3 flex items-center gap-1.5">
 					<h2 class="text-lg font-semibold">Category Overview</h2>
 					<InfoTooltip
-						text="Your top 6 budget categories ranked by risk — over-budget categories appear first, followed by those with the highest percentage of their budget used. Click any card to see the individual transactions."
+						text={monthStatus === 'past'
+							? 'Your top 6 budget categories ranked by how they finished — over-budget categories appear first, followed by those with the highest percentage of their budget used. Click any card to see the individual transactions.'
+							: monthStatus === 'future'
+								? 'Your top 6 budget categories ranked by projected risk — over-budget categories appear first, followed by those with the highest percentage of their budget used. Click any card to see the individual transactions.'
+								: 'Your top 6 budget categories ranked by risk — over-budget categories appear first, followed by those with the highest percentage of their budget used. Click any card to see the individual transactions.'}
 					/>
 				</div>
 				<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
## Summary
- Safe to Spend title, Cash Flow Projection's header tooltip and left-panel row labels, Monthly Overview's status line and left/remaining amounts, and the KPI-row/Category-Overview tooltips now switch between present, past, and future/projected tense based on `getMonthProgress(month, year).status` (the same status already used by #330/#331 to hide figures that don't make sense outside the current month).
- `MonthlyBudgetSummaryCard` previously had no `month`/`year` props at all; added them (following the pattern already used by `CashFlowProjectionCard`/`SafeToSpendHeroBand`) so it can derive month status and adjust its copy.
- Out of scope: `RecurringExpensesCard` (badges fully hidden outside current month), `UpcomingBillsCard` (only rendered for current month), `BudgetProgressCard` (shared with the Categories page).

Closes #336

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run test` — 347 tests pass (updated `MonthlyBudgetSummaryCard.test.ts` for new required props)
- [x] `npm run fmt:check` / `npm run lint` — clean
- [x] Manually verified in the browser for current (August), past (June), and future (December) months: Safe to Spend title, Cash Flow Projection header tooltip + left-panel labels, Monthly Overview status line + left/remaining amounts, and KPI-row/Category-Overview tooltips all read correctly for each tense

🤖 Generated with [Claude Code](https://claude.com/claude-code)