### PR TITLE
Enforce automatic password rotation policy

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -53,6 +53,14 @@ export const variables = defineEnvVars({
 		description: 'Comma-separated list of hardcoded admin user IDs',
 		schema: z.string().default('dummy_admin_id')
 	},
+	PASSWORD_ROTATION_DAYS: {
+		description: 'Number of days before a password is considered expired and rotation is enforced',
+		schema: z
+			.string()
+			.default('120')
+			.transform((v) => Number(v))
+			.pipe(z.number().int().positive())
+	},
 	AUTH_ALERTS_URL: {
 		description: 'Ntfy.sh URL for authentication and security alert push notifications',
 		schema: z.url().default('https://notification-service.com/dummy-auth-alerts')

--- a/src/lib/server/password-policy.test.ts
+++ b/src/lib/server/password-policy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$app/env/private', () => ({
+	PASSWORD_ROTATION_DAYS: 120
+}));
+
+import { isPasswordExpired } from './password-policy';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('isPasswordExpired', () => {
+	it('returns false for a password changed recently', () => {
+		expect(isPasswordExpired(new Date(Date.now() - 1 * DAY_MS))).toBe(false);
+	});
+
+	it('returns false for a password exactly at the threshold', () => {
+		expect(isPasswordExpired(new Date(Date.now() - 120 * DAY_MS))).toBe(false);
+	});
+
+	it('returns true for a password older than the threshold', () => {
+		expect(isPasswordExpired(new Date(Date.now() - 121 * DAY_MS))).toBe(true);
+	});
+
+	it('returns false when there is no recorded password change', () => {
+		expect(isPasswordExpired(null)).toBe(false);
+		expect(isPasswordExpired(undefined)).toBe(false);
+	});
+});

--- a/src/lib/server/password-policy.ts
+++ b/src/lib/server/password-policy.ts
@@ -1,0 +1,12 @@
+import { PASSWORD_ROTATION_DAYS } from '$app/env/private';
+
+/**
+ * Whether a password is old enough to require forced rotation.
+ * `passwordUpdatedAt` is missing for users without a credential account yet,
+ * in which case rotation doesn't apply.
+ */
+export function isPasswordExpired(passwordUpdatedAt: Date | null | undefined): boolean {
+	if (!passwordUpdatedAt) return false;
+	const ageMs = Date.now() - new Date(passwordUpdatedAt).getTime();
+	return ageMs > PASSWORD_ROTATION_DAYS * 24 * 60 * 60 * 1000;
+}

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -1,6 +1,7 @@
 import { SIGN_IN_ROUTE } from '$lib/server/auth-guard-load';
-import { categoryQueries } from '$lib/server/db/queries';
+import { accountQueries, categoryQueries } from '$lib/server/db/queries';
 import { logger } from '$lib/server/logger';
+import { isPasswordExpired } from '$lib/server/password-policy';
 import { redirect } from '@sveltejs/kit';
 
 import type { LayoutServerLoad } from './$types';
@@ -16,6 +17,14 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 	// Redirect to sign-in if not authenticated for other routes
 	if (!locals.user) {
 		throw redirect(302, SIGN_IN_ROUTE);
+	}
+
+	// Force password rotation once expired, until the user updates it on /profile
+	if (!url.pathname.startsWith('/profile')) {
+		const account = await accountQueries.findByUserId(locals.user.id);
+		if (isPasswordExpired(account?.updatedAt)) {
+			throw redirect(302, '/profile?passwordExpired=true');
+		}
 	}
 
 	try {

--- a/src/routes/(app)/profile/+page.server.ts
+++ b/src/routes/(app)/profile/+page.server.ts
@@ -13,7 +13,7 @@ import { zod4 } from 'sveltekit-superforms/adapters';
 
 import type { Actions, PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, url }) => {
 	const currentUser = requireUser(locals);
 
 	// Get the full user data including updatedAt
@@ -33,7 +33,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 		user: fullUserData || currentUser,
 		profileForm,
 		passwordForm,
-		passwordUpdatedAt: accountData?.updatedAt || null
+		passwordUpdatedAt: accountData?.updatedAt || null,
+		passwordExpired: url.searchParams.get('passwordExpired') === 'true'
 	};
 };
 

--- a/src/routes/(app)/profile/+page.svelte
+++ b/src/routes/(app)/profile/+page.svelte
@@ -52,7 +52,8 @@
 
 	// Profile editing state
 	let isEditingProfile = $state(false);
-	let isEditingPassword = $state(false);
+	// svelte-ignore state_referenced_locally
+	let isEditingPassword = $state(data.passwordExpired);
 
 	// Derived values from data
 	const userEmail = $derived(data.user?.email || '');
@@ -84,6 +85,17 @@
 	</div>
 
 	<div class="space-y-6">
+		{#if data.passwordExpired}
+			<div
+				class="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-800"
+			>
+				<AlertCircleIcon class="h-4 w-4 shrink-0" />
+				<span class="text-sm">
+					Your password has expired and must be changed before you can continue using the app.
+				</span>
+			</div>
+		{/if}
+
 		<!-- Profile Information Section -->
 		<div class="overflow-hidden rounded-lg border shadow">
 			<div class="p-6">


### PR DESCRIPTION
## Summary
- Adds a configurable `PASSWORD_ROTATION_DAYS` env var (default 120 days) and a small `isPasswordExpired` helper (`src/lib/server/password-policy.ts`).
- Enforces it in `(app)/+layout.server.ts`: once a user's password is older than the threshold, every route redirects to `/profile?passwordExpired=true` until they change it. Applies uniformly, no admin exemption.
- `/profile` shows a warning banner and auto-opens the change-password form when redirected here for this reason.

No new DB field/migration was needed — better-auth already auto-stamps `account.updatedAt` on every `changePassword`/`resetPassword` call (confirmed by reading the `onUpdate` field hooks in `@better-auth/core`), and `/profile` already read that same value to show "password last updated". This PR just adds the enforcement layer on top of data that already existed.

Closes #340

## Test plan
- [x] `npm run test` — all 351 tests pass (new `password-policy.test.ts` covers fresh/boundary/expired/missing-account cases)
- [x] `npm run check` — 0 errors/warnings
- [x] `npm run lint` — no new findings (pre-existing dead-code dependency warning, unrelated to this change)
- [x] Manual verification against the running dev server (Chrome extension wasn't connected, so verified via direct HTTP requests instead of an interactive browser session): signed in via `/api/auth/sign-in/email`, confirmed `/dashboard` redirects to `/profile?passwordExpired=true` with `PASSWORD_ROTATION_DAYS=1` against the real (old) dev account password, confirmed `/profile` renders the banner without a redirect loop, and confirmed normal navigation resumes with a generous threshold (`PASSWORD_ROTATION_DAYS=300`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)