### PR TITLE
Increase font size in Customer Detail Sheet

### DIFF
--- a/src/routes/(app)/window-cleaning/+page.svelte
+++ b/src/routes/(app)/window-cleaning/+page.svelte
@@ -166,8 +166,8 @@
 <Sheet.Root bind:open={openSheet}>
 	<Sheet.Content side="right" class="flex w-full flex-col sm:max-w-2xl">
 		<Sheet.Header>
-			<Sheet.Title>{selectedCustomer?.name ?? 'Customer'}</Sheet.Title>
-			<Sheet.Description>
+			<Sheet.Title class="text-xl">{selectedCustomer?.name ?? 'Customer'}</Sheet.Title>
+			<Sheet.Description class="text-base">
 				{#if selectedCustomer}
 					{selectedCustomer.address}{selectedCustomer.unitNumber
 						? `, Unit ${selectedCustomer.unitNumber}`
@@ -179,7 +179,7 @@
 		{#if selectedCustomer}
 			<div class="flex-1 overflow-y-auto px-4 py-3">
 				<!-- Customer Info -->
-				<div class="mb-4 space-y-1 text-sm">
+				<div class="mb-4 space-y-1 text-base">
 					{#if selectedCustomer.buzzerNumber}
 						<p class="text-muted-foreground">Buzzer: {selectedCustomer.buzzerNumber}</p>
 					{/if}


### PR DESCRIPTION
## Summary
- Bumps `Sheet.Title` (customer name) to `text-xl` and `Sheet.Description` (address/unit/city) to `text-base` for the Window Cleaning Customer Detail Sheet only, via local `class` overrides so the shared shadcn `Sheet.Title`/`Sheet.Description` defaults are untouched for other usages (e.g. `CategoryTransactionSheet.svelte`).
- Bumps the wrapping info block's `text-sm` to `text-base` so buzzer # and phone number inherit the larger size.
- Notes block, customer list table, and Stats/Jobs sections are unchanged (out of scope per the issue).

Closes #362

## Test plan
- [x] `npm run check` — 0 errors
- [x] Pre-commit/pre-push hooks (fmt, lint, svelte-check, full test suite) passed
- [x] Visual check in browser — the Claude in Chrome extension wasn't connected in this session, so I wasn't able to visually confirm the rendered sizes. This is a minimal, well-understood Tailwind class change; recommend a quick manual check of the Window Cleaning customer sheet before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)